### PR TITLE
Get and use the Python lib path for CMake. closes #31

### DIFF
--- a/cmake/FindPythonLibsNew.cmake
+++ b/cmake/FindPythonLibsNew.cmake
@@ -83,6 +83,7 @@ print(s.get_config_var('SO'));
 print(hasattr(sys, 'gettotalrefcount')+0);
 print(struct.calcsize('@P'));
 print(s.get_config_var('LDVERSION') or s.get_config_var('VERSION'));
+print(s.get_config_var('LIBPL'));
 "
     RESULT_VARIABLE _PYTHON_SUCCESS
     OUTPUT_VARIABLE _PYTHON_VALUES
@@ -109,6 +110,7 @@ list(GET _PYTHON_VALUES 4 PYTHON_MODULE_EXTENSION)
 list(GET _PYTHON_VALUES 5 PYTHON_IS_DEBUG)
 list(GET _PYTHON_VALUES 6 PYTHON_SIZEOF_VOID_P)
 list(GET _PYTHON_VALUES 7 PYTHON_LIBRARY_SUFFIX)
+list(GET _PYTHON_VALUES 8 PYTHON_LIBRARY_PATH)
 
 # Make sure the Python has the same pointer-size as the chosen compiler
 # Skip the check on OS X, it doesn't consistently have CMAKE_SIZEOF_VOID_P defined
@@ -152,9 +154,9 @@ elseif(APPLE)
     #    "${PYTHON_PREFIX}/lib/libpython${PYTHON_LIBRARY_SUFFIX}.dylib")
 else()
     if(${PYTHON_SIZEOF_VOID_P} MATCHES 8)
-        set(_PYTHON_LIBS_SEARCH "${PYTHON_PREFIX}/lib64" "${PYTHON_PREFIX}/lib")
+        set(_PYTHON_LIBS_SEARCH "${PYTHON_PREFIX}/lib64" "${PYTHON_PREFIX}/lib" "${PYTHON_LIBRARY_PATH}")
     else()
-        set(_PYTHON_LIBS_SEARCH "${PYTHON_PREFIX}/lib")
+        set(_PYTHON_LIBS_SEARCH "${PYTHON_PREFIX}/lib" "${PYTHON_LIBRARY_PATH}")
     endif()
     message(STATUS "Searching for Python libs in ${_PYTHON_LIBS_SEARCH}")
     # Probably this needs to be more involved. It would be nice if the config


### PR DESCRIPTION
Fix non standard python lib path when libpythonX.Y.so is not in '/usr/lib'
(Debian multiarch for instance). Use the 'LIBPL' variable from
'disutils.sysconfig' and add it to the list of paths to find the library.
