### PR TITLE
Fix up the build to account for the aux_buffer addition in libdynd

### DIFF
--- a/dynd/_lowlevel/ckernel.py
+++ b/dynd/_lowlevel/ckernel.py
@@ -160,4 +160,4 @@ def arrfunc_instantiate(ckd, out_ckb, ckb_offset, dst_tp, dst_arrmeta,
                     out_ckb, ckb_offset,
                     data_address_of(dst_tp), dst_arrmeta,
                     data_address_of(src_tp), data_address_of(src_arrmeta),
-                    kernreq, ectx_ptr)
+                    kernreq, None, ectx_ptr)

--- a/dynd/_lowlevel/ctypes_types.py
+++ b/dynd/_lowlevel/ctypes_types.py
@@ -91,7 +91,7 @@ InstantiateArrFuncFunction = ctypes.CFUNCTYPE(c_ssize_t,
         ctypes.c_void_p, CKernelBuilderStructPtr, c_ssize_t,
         ctypes.c_void_p, ctypes.c_void_p,
         ctypes.c_void_p, ctypes.c_void_p,
-        ctypes.c_uint32, ctypes.c_void_p)
+        ctypes.c_uint32, ctypes.c_void_p, ctypes.c_void_p)
 if ctypes.sizeof(ctypes.c_void_p) == 8:
     class ArrFuncTypeData(ctypes.Structure):
         _fields_ = [("func_proto", ctypes.c_void_p),

--- a/src/array_as_numpy.cpp
+++ b/src/array_as_numpy.cpp
@@ -744,7 +744,7 @@ PyObject *pydynd::array_as_numpy(PyObject *a_obj, bool allow_copy)
     const char *src_arrmeta = a.get_arrmeta();
     af->instantiate(af, &ckb, 0, ndt::make_type<void>(),
                     reinterpret_cast<const char *>(&dst_arrmeta), &a.get_type(),
-                    &src_arrmeta, kernel_request_single,
+                    &src_arrmeta, kernel_request_single, NULL,
                     &eval::default_eval_context);
     ckb((char *)PyArray_DATA((PyArrayObject *)result.get()),
         a.get_readonly_originptr());

--- a/src/array_as_py.cpp
+++ b/src/array_as_py.cpp
@@ -38,7 +38,7 @@ PyObject* pydynd::array_as_py(const dynd::nd::array& a, bool struct_as_pytuple)
   ndt::type tp = a.get_type();
   const char *arrmeta = a.get_arrmeta();
   af->instantiate(af, &ckb, 0, ndt::make_type<void>(), NULL, &tp, &arrmeta,
-                  kernel_request_single, &eval::default_eval_context);
+                  kernel_request_single, NULL, &eval::default_eval_context);
   pyobject_ownref result;
   ckb(reinterpret_cast<char *>(result.obj_addr()), a.get_readonly_originptr());
   if (PyErr_Occurred()) {

--- a/src/array_assign_from_py.cpp
+++ b/src/array_assign_from_py.cpp
@@ -29,7 +29,7 @@ void pydynd::array_broadcast_assign_from_py(const dynd::ndt::type &dt,
   ndt::type src_tp = ndt::make_type<void>();
   const char *src_arrmeta = NULL;
   af->instantiate(af, &ckb, 0, dt, arrmeta, &src_tp, &src_arrmeta,
-                  kernel_request_single, ectx);
+                  kernel_request_single, NULL, ectx);
   ckb(data, reinterpret_cast<const char *>(&value));
   return;
 }
@@ -51,7 +51,7 @@ void pydynd::array_no_dim_broadcast_assign_from_py(
   ndt::type src_tp = ndt::make_type<void>();
   const char *src_arrmeta = NULL;
   af->instantiate(af, &ckb, 0, dt, arrmeta, &src_tp, &src_arrmeta,
-                  kernel_request_single, ectx);
+                  kernel_request_single, NULL, ectx);
   ckb(data, reinterpret_cast<const char *>(&value));
   return;
 }

--- a/src/arrfunc_from_instantiate_pyfunc.cpp
+++ b/src/arrfunc_from_instantiate_pyfunc.cpp
@@ -31,14 +31,20 @@ namespace {
     }
 
     static intptr_t instantiate_pyfunc_arrfunc_data(
-        const arrfunc_type_data *af_self, dynd::ckernel_builder *ckb, intptr_t ckb_offset,
-        const ndt::type &dst_tp, const char *dst_arrmeta,
+        const arrfunc_type_data *af_self, dynd::ckernel_builder *ckb,
+        intptr_t ckb_offset, const ndt::type &dst_tp, const char *dst_arrmeta,
         const ndt::type *src_tp, const char *const *src_arrmeta,
-        kernel_request_t kernreq, const eval::eval_context *ectx)
+        kernel_request_t kernreq, aux_buffer *aux,
+        const eval::eval_context *ectx)
     {
         PyGILState_RAII pgs;
         PyObject *instantiate_pyfunc = *af_self->get_data_as<PyObject *>();
         intptr_t param_count = af_self->get_param_count();
+
+        if (aux != NULL) {
+          throw invalid_argument("unexpected non-NULL aux value to "
+                                 "instantiate_pyfunc_arrfunc_data");
+        }
 
         // Turn the ckb pointer into an integer
         pyobject_ownref ckb_obj(PyLong_FromSize_t(reinterpret_cast<size_t>(ckb)));

--- a/src/arrfunc_from_pyfunc.cpp
+++ b/src/arrfunc_from_pyfunc.cpp
@@ -173,14 +173,20 @@ namespace {
     }
 
     static intptr_t instantiate_arrfunc_data(
-        const arrfunc_type_data *af_self, dynd::ckernel_builder *ckb, intptr_t ckb_offset,
-        const ndt::type &dst_tp, const char *dst_arrmeta,
+        const arrfunc_type_data *af_self, dynd::ckernel_builder *ckb,
+        intptr_t ckb_offset, const ndt::type &dst_tp, const char *dst_arrmeta,
         const ndt::type *src_tp, const char *const *src_arrmeta,
-        kernel_request_t kernreq, const eval::eval_context *ectx)
+        kernel_request_t kernreq, aux_buffer *aux,
+        const eval::eval_context *ectx)
     {
         typedef pyfunc_expr_ck self_type;
         PyGILState_RAII pgs;
         intptr_t param_count = af_self->get_param_count();
+
+        if (aux != NULL) {
+          throw invalid_argument("unexpected non-NULL aux value to "
+                                 "arrfunc_from_pyfunc instantiation");
+        }
 
         self_type *self = self_type::create(ckb, kernreq, ckb_offset);
         self->m_proto = ndt::make_funcproto(param_count, src_tp, dst_tp);

--- a/src/copy_to_numpy_arrfunc.cpp
+++ b/src/copy_to_numpy_arrfunc.cpp
@@ -40,10 +40,9 @@ struct strided_of_numpy_arrmeta {
  */
 static intptr_t instantiate_copy_to_numpy(
     const arrfunc_type_data *self_af, dynd::ckernel_builder *ckb,
-    intptr_t ckb_offset, const ndt::type &dst_tp,
-    const char *dst_arrmeta, const ndt::type *src_tp,
-    const char *const *src_arrmeta, kernel_request_t kernreq,
-    const eval::eval_context *ectx)
+    intptr_t ckb_offset, const ndt::type &dst_tp, const char *dst_arrmeta,
+    const ndt::type *src_tp, const char *const *src_arrmeta,
+    kernel_request_t kernreq, aux_buffer *aux, const eval::eval_context *ectx)
 {
   if (dst_tp.get_type_id() != void_type_id) {
     stringstream ss;
@@ -51,6 +50,11 @@ static intptr_t instantiate_copy_to_numpy(
     ss << self_af->func_proto << " with types (";
     ss << src_tp[0] << ") -> " << dst_tp;
     throw type_error(ss.str());
+  }
+
+  if (aux != NULL) {
+    throw invalid_argument("unexpected non-NULL aux value to "
+                           "copy_to_numpy instantiation");
   }
 
   PyObject *dst_obj = *reinterpret_cast<PyObject *const *>(dst_arrmeta);
@@ -95,7 +99,7 @@ static intptr_t instantiate_copy_to_numpy(
     } else if (PyDataType_ISOBJECT(dtype)) {
       const arrfunc_type_data *af = copy_to_pyobject_tuple.get();
       return af->instantiate(af, ckb, ckb_offset, ndt::make_type<void>(), NULL,
-                             src_tp, src_arrmeta, kernreq, ectx);
+                             src_tp, src_arrmeta, kernreq, NULL, ectx);
     } else if (PyDataType_HASFIELDS(dtype)) {
       if (src_tp[0].get_kind() != struct_kind &&
           src_tp[0].get_kind() != tuple_kind) {

--- a/src/copy_to_pyobject_arrfunc.cpp
+++ b/src/copy_to_pyobject_arrfunc.cpp
@@ -553,7 +553,7 @@ static intptr_t instantiate_copy_to_pyobject(
     const arrfunc_type_data *self_af, dynd::ckernel_builder *ckb,
     intptr_t ckb_offset, const ndt::type &dst_tp, const char *dst_arrmeta,
     const ndt::type *src_tp, const char *const *src_arrmeta,
-    kernel_request_t kernreq, const eval::eval_context *ectx)
+    kernel_request_t kernreq, aux_buffer *aux, const eval::eval_context *ectx)
 {
   if (dst_tp.get_type_id() != void_type_id) {
     stringstream ss;
@@ -561,6 +561,11 @@ static intptr_t instantiate_copy_to_pyobject(
     ss << self_af->func_proto << " with types (";
     ss << src_tp[0] << ") -> " << dst_tp;
     throw type_error(ss.str());
+  }
+
+  if (aux != NULL) {
+    throw invalid_argument("unexpected non-NULL aux value to "
+                           "copy_to_pyobject instantiation");
   }
 
   bool struct_as_pytuple = *self_af->get_data_as<bool>();
@@ -702,15 +707,15 @@ static intptr_t instantiate_copy_to_pyobject(
     const arrfunc_type_data *is_avail_af =
         src_tp[0].tcast<option_type>()->get_is_avail_arrfunc();
     ckb_offset = is_avail_af->instantiate(
-        is_avail_af, ckb, ckb_offset, ndt::make_type<dynd_bool>(), NULL,
-        src_tp, src_arrmeta, kernel_request_single, ectx);
+        is_avail_af, ckb, ckb_offset, ndt::make_type<dynd_bool>(), NULL, src_tp,
+        src_arrmeta, kernel_request_single, NULL, ectx);
     ckb->ensure_capacity(ckb_offset);
     self = ckb->get_at<option_ck>(root_ckb_offset);
     self->m_copy_value_offset = ckb_offset - root_ckb_offset;
     ndt::type src_value_tp = src_tp[0].tcast<option_type>()->get_value_type();
     ckb_offset = self_af->instantiate(self_af, ckb, ckb_offset, dst_tp,
                                       dst_arrmeta, &src_value_tp, src_arrmeta,
-                                      kernel_request_single, ectx);
+                                      kernel_request_single, NULL, ectx);
     return ckb_offset;
   }
   case strided_dim_type_id:
@@ -726,7 +731,7 @@ static intptr_t instantiate_copy_to_pyobject(
       self->m_stride = stride;
       return self_af->instantiate(self_af, ckb, ckb_offset, dst_tp, dst_arrmeta,
                                   &el_tp, &el_arrmeta, kernel_request_strided,
-                                  ectx);
+                                  NULL, ectx);
     }
     break;
   }
@@ -740,7 +745,7 @@ static intptr_t instantiate_copy_to_pyobject(
     const char *el_arrmeta = src_arrmeta[0] + sizeof(var_dim_type_arrmeta);
     return self_af->instantiate(self_af, ckb, ckb_offset, dst_tp, dst_arrmeta,
                                 &el_tp, &el_arrmeta, kernel_request_strided,
-                                ectx);
+                                NULL, ectx);
   }
   case cstruct_type_id:
   case struct_type_id:
@@ -770,7 +775,7 @@ static intptr_t instantiate_copy_to_pyobject(
         const char *field_arrmeta = src_arrmeta[0] + arrmeta_offsets[i];
         ckb_offset = self_af->instantiate(
             self_af, ckb, ckb_offset, dst_tp, dst_arrmeta, &field_types[i],
-            &field_arrmeta, kernel_request_single, ectx);
+            &field_arrmeta, kernel_request_single, NULL, ectx);
       }
       return ckb_offset;
     }
@@ -794,7 +799,7 @@ static intptr_t instantiate_copy_to_pyobject(
       const char *field_arrmeta = src_arrmeta[0] + arrmeta_offsets[i];
       ckb_offset = self_af->instantiate(
           self_af, ckb, ckb_offset, dst_tp, dst_arrmeta, &field_types[i],
-          &field_arrmeta, kernel_request_single, ectx);
+          &field_arrmeta, kernel_request_single, NULL, ectx);
     }
     return ckb_offset;
   }
@@ -803,7 +808,7 @@ static intptr_t instantiate_copy_to_pyobject(
     ndt::type src_value_tp = src_tp[0].tcast<pointer_type>()->get_target_type();
     return self_af->instantiate(self_af, ckb, ckb_offset, dst_tp, dst_arrmeta,
                                 &src_value_tp, src_arrmeta,
-                                kernel_request_single, ectx);
+                                kernel_request_single, NULL, ectx);
   }
   default:
     break;

--- a/src/numpy_ufunc_kernel.cpp
+++ b/src/numpy_ufunc_kernel.cpp
@@ -241,10 +241,11 @@ namespace {
     }
 
     static intptr_t instantiate_scalar_ufunc_ckernel(
-        const arrfunc_type_data *af_self, dynd::ckernel_builder *ckb, intptr_t ckb_offset,
-        const ndt::type &dst_tp, const char *DYND_UNUSED(dst_arrmeta),
-        const ndt::type *src_tp, const char *const *DYND_UNUSED(src_arrmeta),
-        kernel_request_t kernreq, const eval::eval_context *DYND_UNUSED(ectx))
+        const arrfunc_type_data *af_self, dynd::ckernel_builder *ckb,
+        intptr_t ckb_offset, const ndt::type &dst_tp,
+        const char *DYND_UNUSED(dst_arrmeta), const ndt::type *src_tp,
+        const char *const *DYND_UNUSED(src_arrmeta), kernel_request_t kernreq,
+        aux_buffer *aux, const eval::eval_context *DYND_UNUSED(ectx))
     {
       if (dst_tp != af_self->get_return_type()) {
         stringstream ss;
@@ -262,6 +263,11 @@ namespace {
              << af_self->get_param_type(i);
           throw type_error(ss.str());
         }
+      }
+
+      if (aux != NULL) {
+        throw invalid_argument("unexpected non-NULL aux value to "
+                               "numpy ufunc/arrfunc adapter instantiation");
       }
 
       // Acquire the GIL for creating the ckernel


### PR DESCRIPTION
Currently expect it to always be NULL, until the path through
the python interface is worked out.
