### PR TITLE
Fix up copy_to_numpy and copy_from_numpy to reflect elwise refactor

### DIFF
--- a/dynd/include/copy_from_numpy_arrfunc.hpp
+++ b/dynd/include/copy_from_numpy_arrfunc.hpp
@@ -3,8 +3,7 @@
 // BSD 2-Clause License, see LICENSE.txt
 //
 
-#ifndef PYDYND_COPY_FROM_NUMPY_ARRFUNC_HPP
-#define PYDYND_COPY_FROM_NUMPY_ARRFUNC_HPP
+#pragma once
 
 #include "numpy_interop.hpp"
 
@@ -16,15 +15,13 @@ namespace pydynd {
 
 #ifdef DYND_NUMPY_INTEROP
 
-
 /**
  * This is the arrmeta to provide for the source
  * void type when instantiating the copy_from_numpy arrfunc.
  */
 struct copy_from_numpy_arrmeta {
-  // This is either the source PyArrayObject *,
-  // or the source PyArray_Descr *.
-  PyObject *src_obj;
+  // This is the source PyArray_Descr *.
+  PyArray_Descr *src_dtype;
   // This is the | together of the root data
   // pointer and all the strides/offsets, and
   // can be used to determine the minimum data alignment.
@@ -37,11 +34,9 @@ extern struct copy_from_numpy : dynd::nd::declfunc<copy_from_numpy> {
 
 void array_copy_from_numpy(const dynd::ndt::type &dst_tp,
                            const char *dst_arrmeta, char *dst_data,
-                           PyArrayObject *value,
+                           PyArrayObject *src_arr,
                            const dynd::eval::eval_context *ectx);
 
 #endif
 
 } // namespace pydynd
-
-#endif // PYDYND_COPY_FROM_NUMPY_ARRFUNC_HPP

--- a/dynd/include/copy_to_numpy_arrfunc.hpp
+++ b/dynd/include/copy_to_numpy_arrfunc.hpp
@@ -3,10 +3,9 @@
 // BSD 2-Clause License, see LICENSE.txt
 //
 
-#ifndef PYDYND_COPY_TO_NUMPY_ARRFUNC_HPP
-#define PYDYND_COPY_TO_NUMPY_ARRFUNC_HPP
+#pragma once
 
-#include <Python.h>
+#include "numpy_interop.hpp"
 
 #include <dynd/func/arrfunc.hpp>
 
@@ -17,9 +16,8 @@ namespace pydynd {
  * void type when instantiating the copy_to_numpy arrfunc.
  */
 struct copy_to_numpy_arrmeta {
-  // This is either the destination PyArrayObject *,
-  // or the destination PyArray_Descr *.
-  PyObject *dst_obj;
+  // This is the destination PyArray_Descr *.
+  PyArray_Descr *dst_dtype;
   // This is the | together of the root data
   // pointer and all the strides/offsets, and
   // can be used to determine the minimum data alignment.
@@ -30,6 +28,8 @@ extern struct copy_to_numpy : dynd::nd::declfunc<copy_to_numpy> {
   static dynd::nd::arrfunc make();
 } copy_to_numpy;
 
-} // namespace pydynd
+void array_copy_to_numpy(PyArrayObject *dst_arr, const dynd::ndt::type &src_tp,
+                         const char *src_arrmeta, const char *src_data,
+                         const dynd::eval::eval_context *ectx);
 
-#endif // PYDYND_COPY_TO_NUMPY_ARRFUNC_HPP
+} // namespace pydynd

--- a/src/array_as_numpy.cpp
+++ b/src/array_as_numpy.cpp
@@ -734,19 +734,9 @@ PyObject *pydynd::array_as_numpy(PyObject *a_obj, bool allow_copy)
     pyobject_ownref result(PyArray_NewFromDescr(
         &PyArray_Type, (PyArray_Descr *)numpy_dtype.release(), (int)ndim,
         shape.get(), strides.get(), NULL, 0, NULL));
-    unary_ckernel_builder ckb;
-    copy_to_numpy_arrmeta dst_arrmeta;
-    dst_arrmeta.dst_obj = result.get();
-    dst_arrmeta.dst_alignment = 0;
-    const arrfunc_type_data *af = static_cast<dynd::nd::arrfunc>(copy_to_numpy).get();
-    const char *src_arrmeta = a.get_arrmeta();
-    af->instantiate(af, static_cast<dynd::nd::arrfunc>(copy_to_numpy).get_type(), NULL, &ckb, 0,
-                    ndt::make_type<void>(),
-                    reinterpret_cast<const char *>(&dst_arrmeta), 1, &a.get_type(),
-                    &src_arrmeta, kernel_request_single,
-                    &eval::default_eval_context, nd::array(), std::map<nd::string, ndt::type>());
-    ckb((char *)PyArray_DATA((PyArrayObject *)result.get()),
-        const_cast<char *>(a.get_readonly_originptr()));
+    array_copy_to_numpy((PyArrayObject *)result.get(), a.get_type(),
+                        a.get_arrmeta(), a.get_readonly_originptr(),
+                        &eval::default_eval_context);
 
     // Return the NumPy array
     return result.release();

--- a/src/copy_from_numpy_arrfunc.cpp
+++ b/src/copy_from_numpy_arrfunc.cpp
@@ -49,136 +49,111 @@ static intptr_t instantiate_copy_from_numpy(
     throw type_error(ss.str());
   }
 
-  PyObject *src_obj = *reinterpret_cast<PyObject *const *>(src_arrmeta[0]);
+  PyArray_Descr *dtype =
+      *reinterpret_cast<PyArray_Descr *const *>(src_arrmeta[0]);
   uintptr_t src_alignment =
       reinterpret_cast<const uintptr_t *>(src_arrmeta[0])[1];
 
-  if (PyArray_Check(src_obj)) {
-    PyArrayObject *src_arr = reinterpret_cast<PyArrayObject *>(src_obj);
-    intptr_t src_ndim = PyArray_NDIM(src_arr);
-    src_alignment |= reinterpret_cast<uintptr_t>(PyArray_DATA(src_arr));
-
-    strided_of_numpy_arrmeta src_am_holder;
-    const char *src_am = reinterpret_cast<const char *>(
-        &src_am_holder.sdt[NPY_MAXDIMS - src_ndim]);
-    // Fill in metadata for a multi-dim strided array, corresponding
-    // to the numpy array, with a void type at the end for the numpy
-    // specific data.
-    for (intptr_t i = 0; i < src_ndim; ++i) {
-      fixed_dim_type_arrmeta &am =
-          src_am_holder.sdt[NPY_MAXDIMS - src_ndim + i];
-      am.dim_size = PyArray_DIM(src_arr, (int)i);
-      am.stride = am.dim_size != 1 ? PyArray_STRIDE(src_arr, (int)i) : 0;
-      src_alignment |= static_cast<uintptr_t>(am.stride);
-    }
-    ndt::type src_am_tp = ndt::make_type(src_ndim, PyArray_SHAPE(src_arr),
-                                         ndt::make_type<void>());
-    src_am_holder.am.src_obj =
-        reinterpret_cast<PyObject *>(PyArray_DTYPE(src_arr));
-    src_am_holder.am.src_alignment = src_alignment;
-    // Use the lifting ckernel mechanism to deal with all the dimensions,
-    // calling back to this arrfunc when the dtype is reached
-    return nd::functional::elwise_virtual_ck::instantiate_with_child(
-        self_af, af_tp, NULL, ckb, ckb_offset, dst_tp, dst_arrmeta, 1, &src_am_tp,
-        &src_am, kernreq, ectx, nd::array(), tp_vars);
-  } else {
-    PyArray_Descr *dtype = reinterpret_cast<PyArray_Descr *>(src_obj);
-    if (!PyDataType_FLAGCHK(dtype, NPY_ITEM_HASOBJECT)) {
-      // If there is no object type in the numpy type, get the dynd equivalent
-      // type and use it to do the copying
-      ndt::type src_view_tp = ndt_type_from_numpy_dtype(dtype, src_alignment);
-      return make_assignment_kernel(NULL, NULL, ckb, ckb_offset, dst_tp,
-                                    dst_arrmeta, src_view_tp, NULL, kernreq,
-                                    ectx, nd::array());
-    } else if (PyDataType_ISOBJECT(dtype)) {
-      const arrfunc_type_data *af = static_cast<dynd::nd::arrfunc>(copy_from_pyobject).get();
-      return af->instantiate(af, static_cast<dynd::nd::arrfunc>(copy_from_pyobject).get_type(), NULL, ckb, ckb_offset,
-                             dst_tp, dst_arrmeta, 1, src_tp, src_arrmeta, kernreq,
-                             ectx, nd::array(), tp_vars);
-    } else if (PyDataType_HASFIELDS(dtype)) {
-      if (dst_tp.get_kind() != struct_kind && dst_tp.get_kind() != tuple_kind) {
-        stringstream ss;
-        ss << "Cannot assign from numpy type "
-           << pyobject_repr((PyObject *)dtype) << " to dynd type " << dst_tp;
-        throw invalid_argument(ss.str());
-      }
-
-      // Get the fields out of the numpy dtype
-      vector<PyArray_Descr *> field_dtypes_orig;
-      vector<string> field_names_orig;
-      vector<size_t> field_offsets_orig;
-      extract_fields_from_numpy_struct(dtype, field_dtypes_orig,
-                                       field_names_orig, field_offsets_orig);
-      intptr_t field_count = field_dtypes_orig.size();
-      if (field_count !=
-          dst_tp.extended<base_tuple_type>()->get_field_count()) {
-        stringstream ss;
-        ss << "Cannot assign from numpy type "
-           << pyobject_repr((PyObject *)dtype) << " to dynd type " << dst_tp;
-        throw invalid_argument(ss.str());
-      }
-
-      // Permute the numpy fields to match with the dynd fields
-      vector<PyArray_Descr *> field_dtypes;
-      vector<size_t> field_offsets;
-      if (dst_tp.get_kind() == struct_kind) {
-        field_dtypes.resize(field_count);
-        field_offsets.resize(field_count);
-        for (intptr_t i = 0; i < field_count; ++i) {
-          intptr_t src_i = dst_tp.extended<base_struct_type>()->get_field_index(
-              field_names_orig[i]);
-          if (src_i >= 0) {
-            field_dtypes[src_i] = field_dtypes_orig[i];
-            field_offsets[src_i] = field_offsets_orig[i];
-          } else {
-            stringstream ss;
-            ss << "Cannot assign from numpy type "
-               << pyobject_repr((PyObject *)dtype) << " to dynd type "
-               << dst_tp;
-            throw invalid_argument(ss.str());
-          }
-        }
-      } else {
-        // In the tuple case, use position instead of name
-        field_dtypes.swap(field_dtypes_orig);
-        field_offsets.swap(field_offsets_orig);
-      }
-
-      vector<ndt::type> src_fields_tp(field_count, ndt::make_type<void>());
-      vector<copy_from_numpy_arrmeta> src_arrmeta_values(field_count);
-      vector<const char *> src_fields_arrmeta(field_count);
-      for (intptr_t i = 0; i < field_count; ++i) {
-        src_arrmeta_values[i].src_obj = (PyObject *)field_dtypes[i];
-        src_arrmeta_values[i].src_alignment = src_alignment | field_offsets[i];
-        src_fields_arrmeta[i] =
-            reinterpret_cast<const char *>(&src_arrmeta_values[i]);
-      }
-
-      const uintptr_t *dst_arrmeta_offsets =
-          dst_tp.extended<base_tuple_type>()->get_arrmeta_offsets_raw();
-      shortvector<const char *> dst_fields_arrmeta(field_count);
-      for (intptr_t i = 0; i != field_count; ++i) {
-        dst_fields_arrmeta[i] = dst_arrmeta + dst_arrmeta_offsets[i];
-      }
-
-      return make_tuple_unary_op_ckernel(
-          self_af, af_tp, ckb, ckb_offset, field_count,
-          dst_tp.extended<base_tuple_type>()->get_data_offsets(dst_arrmeta),
-          dst_tp.extended<base_tuple_type>()->get_field_types_raw(),
-          dst_fields_arrmeta.get(), &field_offsets[0], &src_fields_tp[0],
-          &src_fields_arrmeta[0], kernreq, ectx);
-    } else {
+  if (!PyDataType_FLAGCHK(dtype, NPY_ITEM_HASOBJECT)) {
+    // If there is no object type in the numpy type, get the dynd equivalent
+    // type and use it to do the copying
+    ndt::type src_view_tp = ndt_type_from_numpy_dtype(dtype, src_alignment);
+    return make_assignment_kernel(NULL, NULL, ckb, ckb_offset, dst_tp,
+                                  dst_arrmeta, src_view_tp, NULL, kernreq, ectx,
+                                  nd::array());
+  }
+  else if (PyDataType_ISOBJECT(dtype)) {
+    const arrfunc_type_data *af =
+        static_cast<dynd::nd::arrfunc>(copy_from_pyobject).get();
+    return af->instantiate(
+        af, static_cast<dynd::nd::arrfunc>(copy_from_pyobject).get_type(), NULL,
+        ckb, ckb_offset, dst_tp, dst_arrmeta, 1, src_tp, src_arrmeta, kernreq,
+        ectx, nd::array(), tp_vars);
+  }
+  else if (PyDataType_HASFIELDS(dtype)) {
+    if (dst_tp.get_kind() != struct_kind && dst_tp.get_kind() != tuple_kind) {
       stringstream ss;
-      ss << "TODO: implement assign from numpy type "
-         << pyobject_repr((PyObject *)dtype) << " to dynd type " << dst_tp;
+      ss << "Cannot assign from numpy type " << pyobject_repr((PyObject *)dtype)
+         << " to dynd type " << dst_tp;
       throw invalid_argument(ss.str());
     }
+
+    // Get the fields out of the numpy dtype
+    vector<PyArray_Descr *> field_dtypes_orig;
+    vector<string> field_names_orig;
+    vector<size_t> field_offsets_orig;
+    extract_fields_from_numpy_struct(dtype, field_dtypes_orig, field_names_orig,
+                                     field_offsets_orig);
+    intptr_t field_count = field_dtypes_orig.size();
+    if (field_count != dst_tp.extended<base_tuple_type>()->get_field_count()) {
+      stringstream ss;
+      ss << "Cannot assign from numpy type " << pyobject_repr((PyObject *)dtype)
+         << " to dynd type " << dst_tp;
+      throw invalid_argument(ss.str());
+    }
+
+    // Permute the numpy fields to match with the dynd fields
+    vector<PyArray_Descr *> field_dtypes;
+    vector<size_t> field_offsets;
+    if (dst_tp.get_kind() == struct_kind) {
+      field_dtypes.resize(field_count);
+      field_offsets.resize(field_count);
+      for (intptr_t i = 0; i < field_count; ++i) {
+        intptr_t src_i = dst_tp.extended<base_struct_type>()->get_field_index(
+            field_names_orig[i]);
+        if (src_i >= 0) {
+          field_dtypes[src_i] = field_dtypes_orig[i];
+          field_offsets[src_i] = field_offsets_orig[i];
+        }
+        else {
+          stringstream ss;
+          ss << "Cannot assign from numpy type "
+             << pyobject_repr((PyObject *)dtype) << " to dynd type " << dst_tp;
+          throw invalid_argument(ss.str());
+        }
+      }
+    }
+    else {
+      // In the tuple case, use position instead of name
+      field_dtypes.swap(field_dtypes_orig);
+      field_offsets.swap(field_offsets_orig);
+    }
+
+    vector<ndt::type> src_fields_tp(field_count, ndt::make_type<void>());
+    vector<copy_from_numpy_arrmeta> src_arrmeta_values(field_count);
+    vector<const char *> src_fields_arrmeta(field_count);
+    for (intptr_t i = 0; i < field_count; ++i) {
+      src_arrmeta_values[i].src_dtype = field_dtypes[i];
+      src_arrmeta_values[i].src_alignment = src_alignment | field_offsets[i];
+      src_fields_arrmeta[i] =
+          reinterpret_cast<const char *>(&src_arrmeta_values[i]);
+    }
+
+    const uintptr_t *dst_arrmeta_offsets =
+        dst_tp.extended<base_tuple_type>()->get_arrmeta_offsets_raw();
+    shortvector<const char *> dst_fields_arrmeta(field_count);
+    for (intptr_t i = 0; i != field_count; ++i) {
+      dst_fields_arrmeta[i] = dst_arrmeta + dst_arrmeta_offsets[i];
+    }
+
+    return make_tuple_unary_op_ckernel(
+        self_af, af_tp, ckb, ckb_offset, field_count,
+        dst_tp.extended<base_tuple_type>()->get_data_offsets(dst_arrmeta),
+        dst_tp.extended<base_tuple_type>()->get_field_types_raw(),
+        dst_fields_arrmeta.get(), &field_offsets[0], &src_fields_tp[0],
+        &src_fields_arrmeta[0], kernreq, ectx);
+  }
+  else {
+    stringstream ss;
+    ss << "TODO: implement assign from numpy type "
+       << pyobject_repr((PyObject *)dtype) << " to dynd type " << dst_tp;
+    throw invalid_argument(ss.str());
   }
 }
 
 static nd::arrfunc make_copy_from_numpy_arrfunc()
 {
-  nd::array out_af = nd::empty(ndt::type("(void) -> A... * T"));
+  nd::array out_af = nd::empty(ndt::type("(void) -> T"));
   arrfunc_type_data *af =
       reinterpret_cast<arrfunc_type_data *>(out_af.get_readwrite_originptr());
   af->instantiate = &instantiate_copy_from_numpy;
@@ -191,24 +166,43 @@ dynd::nd::arrfunc pydynd::copy_from_numpy::make() {
 }
 
 struct pydynd::copy_from_numpy pydynd::copy_from_numpy;
+nd::arrfunc elwise_copy_from_numpy =
+    nd::functional::elwise(pydynd::copy_from_numpy);
 
 void pydynd::array_copy_from_numpy(const ndt::type &dst_tp,
                                    const char *dst_arrmeta, char *dst_data,
-                                   PyArrayObject *value,
+                                   PyArrayObject *src_arr,
                                    const dynd::eval::eval_context *ectx)
 {
+  intptr_t src_ndim = PyArray_NDIM(src_arr);
+
+  strided_of_numpy_arrmeta src_am_holder;
+  const char *src_am = reinterpret_cast<const char *>(
+    &src_am_holder.sdt[NPY_MAXDIMS - src_ndim]);
+  // Fill in metadata for a multi-dim strided array, corresponding
+  // to the numpy array, with a void type at the end for the numpy
+  // specific data.
+  uintptr_t src_alignment = reinterpret_cast<uintptr_t>(PyArray_DATA(src_arr));
+  for (intptr_t i = 0; i < src_ndim; ++i) {
+    fixed_dim_type_arrmeta &am = src_am_holder.sdt[NPY_MAXDIMS - src_ndim + i];
+    am.dim_size = PyArray_DIM(src_arr, (int)i);
+    am.stride = am.dim_size != 1 ? PyArray_STRIDE(src_arr, (int)i) : 0;
+    src_alignment |= static_cast<uintptr_t>(am.stride);
+  }
+  ndt::type src_tp =
+      ndt::make_type(src_ndim, PyArray_SHAPE(src_arr), ndt::make_type<void>());
+  src_am_holder.am.src_dtype = PyArray_DTYPE(src_arr);
+  src_am_holder.am.src_alignment = src_alignment;
+
+  const arrfunc_type_data *af =
+      static_cast<dynd::nd::arrfunc>(elwise_copy_from_numpy).get();
   unary_ckernel_builder ckb;
-  copy_from_numpy_arrmeta src_arrmeta;
-  src_arrmeta.src_obj = (PyObject *)value;
-  src_arrmeta.src_alignment = 0;
-  const char *src_arrmeta_ptr = reinterpret_cast<const char *>(&src_arrmeta);
-  const arrfunc_type_data *af = static_cast<dynd::nd::arrfunc>(copy_from_numpy).get();
-  ndt::type src_tp = ndt::make_type<void>();
-  af->instantiate(af, static_cast<dynd::nd::arrfunc>(copy_from_numpy).get_type(), NULL, &ckb, 0, dst_tp, dst_arrmeta,
-                  1, &src_tp, &src_arrmeta_ptr, kernel_request_single,
-                  &eval::default_eval_context, nd::array(),
-                  std::map<nd::string, ndt::type>());
-  ckb(dst_data, (char *)PyArray_DATA(value));
+  af->instantiate(
+      af, static_cast<dynd::nd::arrfunc>(elwise_copy_from_numpy).get_type(),
+      NULL, &ckb, 0, dst_tp, dst_arrmeta, 1, &src_tp, &src_am,
+      kernel_request_single, ectx, nd::array(),
+      std::map<nd::string, ndt::type>());
+  ckb(dst_data, (char *)PyArray_DATA(src_arr));
 }
 
 #endif // DYND_NUMPY_INTEROP

--- a/src/copy_to_numpy_arrfunc.cpp
+++ b/src/copy_to_numpy_arrfunc.cpp
@@ -36,12 +36,13 @@ struct strided_of_numpy_arrmeta {
  * This sets up a ckernel to copy from a dynd array
  * to a numpy array. The destination numpy array is
  * represented by dst_tp being ``void`` and the dst_arrmeta
- * being a pointer to the ``PyArrayObject *`` for the destination.
+ * being a pointer to the ``PyArray_Descr *`` of the type for the destination.
  */
 static intptr_t instantiate_copy_to_numpy(
-    const arrfunc_type_data *self_af, const arrfunc_type *af_tp, char *DYND_UNUSED(data),
-    void *ckb, intptr_t ckb_offset, const ndt::type &dst_tp, const char *dst_arrmeta,
-    intptr_t nsrc, const ndt::type *src_tp, const char *const *src_arrmeta,
+    const arrfunc_type_data *self_af, const arrfunc_type *af_tp,
+    char *DYND_UNUSED(data), void *ckb, intptr_t ckb_offset,
+    const ndt::type &dst_tp, const char *dst_arrmeta, intptr_t nsrc,
+    const ndt::type *src_tp, const char *const *src_arrmeta,
     kernel_request_t kernreq, const eval::eval_context *ectx,
     const nd::array &kwds, const std::map<nd::string, ndt::type> &tp_vars)
 {
@@ -56,132 +57,107 @@ static intptr_t instantiate_copy_to_numpy(
   PyObject *dst_obj = *reinterpret_cast<PyObject *const *>(dst_arrmeta);
   uintptr_t dst_alignment = reinterpret_cast<const uintptr_t *>(dst_arrmeta)[1];
 
-  if (PyArray_Check(dst_obj)) {
-    PyArrayObject *dst_arr = reinterpret_cast<PyArrayObject *>(dst_obj);
-    intptr_t dst_ndim = PyArray_NDIM(dst_arr);
-    intptr_t src_ndim = src_tp[0].get_ndim();
-    dst_alignment |= reinterpret_cast<uintptr_t>(PyArray_DATA(dst_arr));
-
-    strided_of_numpy_arrmeta dst_am_holder;
-    const char *dst_am = reinterpret_cast<const char *>(
-        &dst_am_holder.sdt[NPY_MAXDIMS - dst_ndim]);
-    // Fill in metadata for a multi-dim strided array, corresponding
-    // to the numpy array, with a void type at the end for the numpy
-    // specific data.
-    for (intptr_t i = 0; i < dst_ndim; ++i) {
-      fixed_dim_type_arrmeta &am =
-          dst_am_holder.sdt[NPY_MAXDIMS - dst_ndim + i];
-      am.stride = PyArray_STRIDE(dst_arr, (int)i);
-      dst_alignment |= static_cast<uintptr_t>(am.stride);
-      am.dim_size = PyArray_DIM(dst_arr, (int)i);
-    }
-    ndt::type dst_am_tp = ndt::make_type(dst_ndim, PyArray_SHAPE(dst_arr),
-                                         ndt::make_type<void>());
-    dst_am_holder.am.dst_obj =
-        reinterpret_cast<PyObject *>(PyArray_DTYPE(dst_arr));
-    dst_am_holder.am.dst_alignment = dst_alignment;
-    // Use the lifting ckernel mechanism to deal with all the dimensions,
-    // calling back to this arrfunc when the dtype is reached
-    return nd::functional::elwise_virtual_ck::instantiate_with_child(self_af, af_tp, NULL, ckb, ckb_offset, dst_am_tp,
-                                  dst_am, nsrc, src_tp, src_arrmeta, kernreq, ectx,
-                                  nd::array(), tp_vars);
-  } else {
-    PyArray_Descr *dtype = reinterpret_cast<PyArray_Descr *>(dst_obj);
-    if (!PyDataType_FLAGCHK(dtype, NPY_ITEM_HASOBJECT)) {
-      // If there is no object type in the numpy type, get the dynd equivalent
-      // type and use it to do the copying
-      ndt::type dst_view_tp = ndt_type_from_numpy_dtype(dtype, dst_alignment);
-      return make_assignment_kernel(NULL, NULL, ckb, ckb_offset, dst_view_tp,
-                                    NULL, src_tp[0], src_arrmeta[0], kernreq,
-                                    ectx, nd::array());
-    } else if (PyDataType_ISOBJECT(dtype)) {
-      const arrfunc_type_data *af = static_cast<dynd::nd::arrfunc>(copy_to_pyobject_tuple).get();
-      return af->instantiate(af, static_cast<dynd::nd::arrfunc>(copy_to_pyobject_tuple).get_type(), NULL, ckb,
-                             ckb_offset, ndt::make_type<void>(), NULL, nsrc, src_tp,
-                             src_arrmeta, kernreq, ectx, nd::array(), tp_vars);
-    } else if (PyDataType_HASFIELDS(dtype)) {
-      if (src_tp[0].get_kind() != struct_kind &&
-          src_tp[0].get_kind() != tuple_kind) {
-        stringstream ss;
-        pyobject_ownref dtype_str(PyObject_Str((PyObject *)dtype));
-        ss << "Cannot assign from source dynd type " << src_tp[0]
-           << " to numpy type " << pystring_as_string(dtype_str.get());
-        throw invalid_argument(ss.str());
-      }
-
-      // Get the fields out of the numpy dtype
-      vector<PyArray_Descr *> field_dtypes_orig;
-      vector<string> field_names_orig;
-      vector<size_t> field_offsets_orig;
-      extract_fields_from_numpy_struct(dtype, field_dtypes_orig,
-                                       field_names_orig, field_offsets_orig);
-      intptr_t field_count = field_dtypes_orig.size();
-      if (field_count !=
-          src_tp[0].extended<base_tuple_type>()->get_field_count()) {
-        stringstream ss;
-        pyobject_ownref dtype_str(PyObject_Str((PyObject *)dtype));
-        ss << "Cannot assign from source dynd type " << src_tp[0]
-           << " to numpy type " << pystring_as_string(dtype_str.get());
-        throw invalid_argument(ss.str());
-      }
-
-      // Permute the numpy fields to match with the dynd fields
-      vector<PyArray_Descr *> field_dtypes;
-      vector<size_t> field_offsets;
-      if (src_tp[0].get_kind() == struct_kind) {
-        field_dtypes.resize(field_count);
-        field_offsets.resize(field_count);
-        for (intptr_t i = 0; i < field_count; ++i) {
-          intptr_t src_i =
-              src_tp[0].extended<base_struct_type>()->get_field_index(
-                  field_names_orig[i]);
-          if (src_i >= 0) {
-            field_dtypes[src_i] = field_dtypes_orig[i];
-            field_offsets[src_i] = field_offsets_orig[i];
-          } else {
-            stringstream ss;
-            pyobject_ownref dtype_str(PyObject_Str((PyObject *)dtype));
-            ss << "Cannot assign from source dynd type " << src_tp[0]
-               << " to numpy type " << pystring_as_string(dtype_str.get());
-            throw invalid_argument(ss.str());
-          }
-        }
-      } else {
-        // In the tuple case, use position instead of name
-        field_dtypes.swap(field_dtypes_orig);
-        field_offsets.swap(field_offsets_orig);
-      }
-
-      vector<ndt::type> dst_fields_tp(field_count, ndt::make_type<void>());
-      vector<copy_to_numpy_arrmeta> dst_arrmeta_values(field_count);
-      vector<const char *> dst_fields_arrmeta(field_count);
-      for (intptr_t i = 0; i < field_count; ++i) {
-        dst_arrmeta_values[i].dst_obj = (PyObject *)field_dtypes[i];
-        dst_arrmeta_values[i].dst_alignment = dst_alignment | field_offsets[i];
-        dst_fields_arrmeta[i] =
-            reinterpret_cast<const char *>(&dst_arrmeta_values[i]);
-      }
-
-      const uintptr_t *src_arrmeta_offsets =
-          src_tp[0].extended<base_tuple_type>()->get_arrmeta_offsets_raw();
-      shortvector<const char *> src_fields_arrmeta(field_count);
-      for (intptr_t i = 0; i != field_count; ++i) {
-        src_fields_arrmeta[i] = src_arrmeta[0] + src_arrmeta_offsets[i];
-      }
-
-      return make_tuple_unary_op_ckernel(
-          self_af, af_tp, ckb, ckb_offset, field_count, &field_offsets[0],
-          &dst_fields_tp[0], &dst_fields_arrmeta[0],
-          src_tp[0].extended<base_tuple_type>()->get_data_offsets(
-              src_arrmeta[0]),
-          src_tp[0].extended<base_tuple_type>()->get_field_types_raw(),
-          src_fields_arrmeta.get(), kernreq, ectx);
-    } else {
+  PyArray_Descr *dtype = reinterpret_cast<PyArray_Descr *>(dst_obj);
+  if (!PyDataType_FLAGCHK(dtype, NPY_ITEM_HASOBJECT)) {
+    // If there is no object type in the numpy type, get the dynd equivalent
+    // type and use it to do the copying
+    ndt::type dst_view_tp = ndt_type_from_numpy_dtype(dtype, dst_alignment);
+    return make_assignment_kernel(NULL, NULL, ckb, ckb_offset, dst_view_tp,
+                                  NULL, src_tp[0], src_arrmeta[0], kernreq,
+                                  ectx, nd::array());
+  }
+  else if (PyDataType_ISOBJECT(dtype)) {
+    const arrfunc_type_data *af =
+        static_cast<dynd::nd::arrfunc>(copy_to_pyobject_tuple).get();
+    return af->instantiate(
+        af, static_cast<dynd::nd::arrfunc>(copy_to_pyobject_tuple).get_type(),
+        NULL, ckb, ckb_offset, ndt::make_type<void>(), NULL, nsrc, src_tp,
+        src_arrmeta, kernreq, ectx, nd::array(), tp_vars);
+  }
+  else if (PyDataType_HASFIELDS(dtype)) {
+    if (src_tp[0].get_kind() != struct_kind &&
+        src_tp[0].get_kind() != tuple_kind) {
       stringstream ss;
-      ss << "TODO: implement assign from source dynd type " << src_tp[0]
-         << " to numpy type " << pyobject_repr((PyObject *)dtype);
+      pyobject_ownref dtype_str(PyObject_Str((PyObject *)dtype));
+      ss << "Cannot assign from source dynd type " << src_tp[0]
+         << " to numpy type " << pystring_as_string(dtype_str.get());
       throw invalid_argument(ss.str());
     }
+
+    // Get the fields out of the numpy dtype
+    vector<PyArray_Descr *> field_dtypes_orig;
+    vector<string> field_names_orig;
+    vector<size_t> field_offsets_orig;
+    extract_fields_from_numpy_struct(dtype, field_dtypes_orig, field_names_orig,
+                                     field_offsets_orig);
+    intptr_t field_count = field_dtypes_orig.size();
+    if (field_count !=
+        src_tp[0].extended<base_tuple_type>()->get_field_count()) {
+      stringstream ss;
+      pyobject_ownref dtype_str(PyObject_Str((PyObject *)dtype));
+      ss << "Cannot assign from source dynd type " << src_tp[0]
+         << " to numpy type " << pystring_as_string(dtype_str.get());
+      throw invalid_argument(ss.str());
+    }
+
+    // Permute the numpy fields to match with the dynd fields
+    vector<PyArray_Descr *> field_dtypes;
+    vector<size_t> field_offsets;
+    if (src_tp[0].get_kind() == struct_kind) {
+      field_dtypes.resize(field_count);
+      field_offsets.resize(field_count);
+      for (intptr_t i = 0; i < field_count; ++i) {
+        intptr_t src_i =
+            src_tp[0].extended<base_struct_type>()->get_field_index(
+                field_names_orig[i]);
+        if (src_i >= 0) {
+          field_dtypes[src_i] = field_dtypes_orig[i];
+          field_offsets[src_i] = field_offsets_orig[i];
+        }
+        else {
+          stringstream ss;
+          pyobject_ownref dtype_str(PyObject_Str((PyObject *)dtype));
+          ss << "Cannot assign from source dynd type " << src_tp[0]
+             << " to numpy type " << pystring_as_string(dtype_str.get());
+          throw invalid_argument(ss.str());
+        }
+      }
+    }
+    else {
+      // In the tuple case, use position instead of name
+      field_dtypes.swap(field_dtypes_orig);
+      field_offsets.swap(field_offsets_orig);
+    }
+
+    vector<ndt::type> dst_fields_tp(field_count, ndt::make_type<void>());
+    vector<copy_to_numpy_arrmeta> dst_arrmeta_values(field_count);
+    vector<const char *> dst_fields_arrmeta(field_count);
+    for (intptr_t i = 0; i < field_count; ++i) {
+      dst_arrmeta_values[i].dst_dtype = field_dtypes[i];
+      dst_arrmeta_values[i].dst_alignment = dst_alignment | field_offsets[i];
+      dst_fields_arrmeta[i] =
+          reinterpret_cast<const char *>(&dst_arrmeta_values[i]);
+    }
+
+    const uintptr_t *src_arrmeta_offsets =
+        src_tp[0].extended<base_tuple_type>()->get_arrmeta_offsets_raw();
+    shortvector<const char *> src_fields_arrmeta(field_count);
+    for (intptr_t i = 0; i != field_count; ++i) {
+      src_fields_arrmeta[i] = src_arrmeta[0] + src_arrmeta_offsets[i];
+    }
+
+    return make_tuple_unary_op_ckernel(
+        self_af, af_tp, ckb, ckb_offset, field_count, &field_offsets[0],
+        &dst_fields_tp[0], &dst_fields_arrmeta[0],
+        src_tp[0].extended<base_tuple_type>()->get_data_offsets(src_arrmeta[0]),
+        src_tp[0].extended<base_tuple_type>()->get_field_types_raw(),
+        src_fields_arrmeta.get(), kernreq, ectx);
+  }
+  else {
+    stringstream ss;
+    ss << "TODO: implement assign from source dynd type " << src_tp[0]
+       << " to numpy type " << pyobject_repr((PyObject *)dtype);
+    throw invalid_argument(ss.str());
   }
 }
 
@@ -200,6 +176,42 @@ dynd::nd::arrfunc pydynd::copy_to_numpy::make() {
 }
 
 struct pydynd::copy_to_numpy pydynd::copy_to_numpy;
+nd::arrfunc elwise_copy_to_numpy =
+    nd::functional::elwise(pydynd::copy_to_numpy);
 
+void pydynd::array_copy_to_numpy(PyArrayObject *dst_arr,
+                                 const dynd::ndt::type &src_tp,
+                                 const char *src_arrmeta, const char *src_data,
+                                 const dynd::eval::eval_context *ectx)
+{
+  intptr_t dst_ndim = PyArray_NDIM(dst_arr);
+  intptr_t src_ndim = src_tp.get_ndim();
+  uintptr_t dst_alignment = reinterpret_cast<uintptr_t>(PyArray_DATA(dst_arr));
+
+  strided_of_numpy_arrmeta dst_am_holder;
+  const char *dst_am = reinterpret_cast<const char *>(
+      &dst_am_holder.sdt[NPY_MAXDIMS - dst_ndim]);
+  // Fill in metadata for a multi-dim strided array, corresponding
+  // to the numpy array, with a void type at the end for the numpy
+  // specific data.
+  for (intptr_t i = 0; i < dst_ndim; ++i) {
+    fixed_dim_type_arrmeta &am = dst_am_holder.sdt[NPY_MAXDIMS - dst_ndim + i];
+    am.stride = PyArray_STRIDE(dst_arr, (int)i);
+    dst_alignment |= static_cast<uintptr_t>(am.stride);
+    am.dim_size = PyArray_DIM(dst_arr, (int)i);
+  }
+  ndt::type dst_tp =
+      ndt::make_type(dst_ndim, PyArray_SHAPE(dst_arr), ndt::make_type<void>());
+  dst_am_holder.am.dst_dtype = PyArray_DTYPE(dst_arr);
+  dst_am_holder.am.dst_alignment = dst_alignment;
+
+  const arrfunc_type_data *af = static_cast<dynd::nd::arrfunc>(elwise_copy_to_numpy).get();
+  unary_ckernel_builder ckb;
+  af->instantiate(
+      af, static_cast<dynd::nd::arrfunc>(elwise_copy_to_numpy).get_type(), NULL,
+      &ckb, 0, dst_tp, dst_am, 1, &src_tp, &src_arrmeta, kernel_request_single,
+      ectx, nd::array(), std::map<nd::string, ndt::type>());
+  ckb((char *)PyArray_DATA(dst_arr), const_cast<char *>(src_data));
+}
 
 #endif // DYND_NUMPY_INTEROP


### PR DESCRIPTION
Instead of having the dual-mode instantiate as it was, the arrfunc
at the core of these copy operations is now just for one numpy element
to/from one dynd element. This arrfunc is lifted via elwise, and
the setup code for the dynd-like array like "Fixed * Fixed * void"
to represent a 2D NumPy array, for example, is now moved out into
the helper function which calls the arrfunc.