### PR TITLE
Fix building of pydynd and Cython modules on Windows MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,11 @@ if (DYND_INSTALL_LIB)
     find_package(LibDyND REQUIRED)
 else()
     # Set some options used by the libdynd CMakeLists.txt
-    set(DYND_SHARED_LIB ON)
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+        set(DYND_SHARED_LIB OFF)
+    else()
+        set(DYND_SHARED_LIB ON)
+    endif()
     # USE_RELATIVE_RPATH is inherited from this cmakelists, so need to set it here
     option(DYND_BUILD_TESTS "Build the googletest unit tests for libdynd." ON)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ option(DYND_INSTALL_LIB
     option(DYND_CUDA
         "Use a libdynd built with CUDA."
         OFF)
-# -DUSE_RELATIVE_RPATH=ON/OFF, For OSX, to use the @rpath mechanism
+# -DUSE_RELATIVE_RPATH=ON/OFF, For Linux and OSX, to use the @rpath mechanism
 #   for creating a build which is linked with relative paths. The
 #   libdynd should have been built with -DUSE_RELATIVE_RPATH=ON as well.
 if(UNIX)
@@ -67,11 +67,7 @@ if (DYND_INSTALL_LIB)
     find_package(LibDyND REQUIRED)
 else()
     # Set some options used by the libdynd CMakeLists.txt
-    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-        set(DYND_SHARED_LIB OFF)
-    else()
-        set(DYND_SHARED_LIB ON)
-    endif()
+    set(DYND_SHARED_LIB ON)
     # USE_RELATIVE_RPATH is inherited from this cmakelists, so need to set it here
     option(DYND_BUILD_TESTS "Build the googletest unit tests for libdynd." ON)
 
@@ -181,6 +177,7 @@ set(pydynd_SRC
     dynd/include/array_functions.hpp
     dynd/include/arrfunc_functions.hpp
     dynd/include/arrfunc_from_pyfunc.hpp
+    dynd/include/config.hpp
     dynd/include/copy_from_numpy_arrfunc.hpp
     dynd/include/copy_from_pyobject_arrfunc.hpp
     dynd/include/copy_to_numpy_arrfunc.hpp
@@ -226,11 +223,21 @@ set(pydynd_SRC
 )
 
 add_library(pydynd SHARED ${pydynd_SRC})
+set_property(
+   TARGET pydynd
+   PROPERTY COMPILE_DEFINITIONS PYDYND_EXPORT
+   )
 
 if(APPLE)
     set_target_properties(pydynd PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+elseif(WIN32)
+    target_link_libraries(pydynd "${PYTHON_LIBRARIES}")
 endif()
-target_link_libraries(pydynd "${LIBDYND_LIBRARIES}")
+if(DYND_INSTALL_LIB)
+    target_link_libraries(pydynd "${LIBDYND_LIBRARIES}")
+else()
+    target_link_libraries(pydynd libdynd)
+endif()
 
 foreach(module config eval_context ndt.type nd.array nd.arrfunc nd.functional)
     string(REPLACE "." ";" directories ${module})

--- a/dynd/include/array_as_numpy.hpp
+++ b/dynd/include/array_as_numpy.hpp
@@ -6,7 +6,7 @@
 #ifndef _DYND__NDARRAY_AS_NUMPY_HPP_
 #define _DYND__NDARRAY_AS_NUMPY_HPP_
 
-#include <Python.h>
+#include "config.hpp"
 
 #include <dynd/array.hpp>
 
@@ -20,7 +20,7 @@ namespace pydynd {
  * \param allow_copy  If true, a copy can be made to make things fit,
  *                    otherwise produce an error instead of a copy.
  */
-PyObject *array_as_numpy(PyObject *a_obj, bool allow_copy);
+PYDYND_API PyObject *array_as_numpy(PyObject *a_obj, bool allow_copy);
 
 } // namespace pydynd
 

--- a/dynd/include/array_as_pep3118.hpp
+++ b/dynd/include/array_as_pep3118.hpp
@@ -10,6 +10,8 @@
 
 #include <dynd/array.hpp>
 
+#include "config.hpp"
+
 namespace pydynd {
 
 /**
@@ -28,12 +30,13 @@ std::string make_pep3118_format(intptr_t &out_itemsize,
 /**
  * \brief Converts an nd::array into a PEP3118 buffer.
  */
-int array_getbuffer_pep3118(PyObject *ndo, Py_buffer *buffer, int flags);
+PYDYND_API int array_getbuffer_pep3118(PyObject *ndo, Py_buffer *buffer,
+                                       int flags);
 
 /**
  * \brief Frees a previously created PEP3118 buffer.
  */
-int array_releasebuffer_pep3118(PyObject *ndo, Py_buffer *buffer);
+PYDYND_API int array_releasebuffer_pep3118(PyObject *ndo, Py_buffer *buffer);
 
 } // namespace pydynd
 

--- a/dynd/include/array_as_py.hpp
+++ b/dynd/include/array_as_py.hpp
@@ -10,6 +10,8 @@
 
 #include <dynd/array.hpp>
 
+#include "config.hpp"
+
 namespace pydynd {
 
 /**
@@ -20,7 +22,8 @@ namespace pydynd {
  * \param struct_as_pytuple  If true, converts structs into tuples, otherwise
  *                           converts them into dicts.
  */
-PyObject *array_as_py(const dynd::nd::array &n, bool struct_as_pytuple);
+PYDYND_API PyObject *array_as_py(const dynd::nd::array &n,
+                                 bool struct_as_pytuple);
 
 /** Converts a uint128 into a PyLong */
 PyObject *pylong_from_uint128(const dynd::uint128 &val);

--- a/dynd/include/array_assign_from_py.hpp
+++ b/dynd/include/array_assign_from_py.hpp
@@ -10,6 +10,8 @@
 
 #include <dynd/array.hpp>
 
+#include "config.hpp"
+
 namespace pydynd {
 
 /**

--- a/dynd/include/array_from_py.hpp
+++ b/dynd/include/array_from_py.hpp
@@ -10,6 +10,8 @@
 
 #include <dynd/array.hpp>
 
+#include "config.hpp"
+
 namespace pydynd {
 
 /**

--- a/dynd/include/array_from_py_dynamic.hpp
+++ b/dynd/include/array_from_py_dynamic.hpp
@@ -10,6 +10,8 @@
 
 #include <dynd/array.hpp>
 
+#include "config.hpp"
+
 namespace pydynd {
 
 /**

--- a/dynd/include/array_from_py_typededuction.hpp
+++ b/dynd/include/array_from_py_typededuction.hpp
@@ -10,6 +10,8 @@
 
 #include <dynd/array.hpp>
 
+#include "config.hpp"
+
 namespace pydynd {
 
 /**

--- a/dynd/include/array_functions.hpp
+++ b/dynd/include/array_functions.hpp
@@ -17,6 +17,7 @@
 #include <dynd/shape_tools.hpp>
 #include <dynd/json_parser.hpp>
 
+#include "config.hpp"
 #include "array_from_py.hpp"
 #include "array_as_py.hpp"
 #include "array_as_numpy.hpp"
@@ -46,39 +47,44 @@ struct WArray {
   dynd::nd::array v;
 };
 
-void init_w_array_typeobject(PyObject *type);
+PYDYND_API void init_w_array_typeobject(PyObject *type);
 
-PyObject *wrap_array(const dynd::nd::array &n);
-PyObject *wrap_array(const dynd::nd::arrfunc &n);
+PYDYND_API PyObject *wrap_array(const dynd::nd::array &n);
+PYDYND_API PyObject *wrap_array(const dynd::nd::arrfunc &n);
 
-void array_init_from_pyobject(dynd::nd::array &n, PyObject *obj, PyObject *dt,
-                              bool uniform, PyObject *access);
-void array_init_from_pyobject(dynd::nd::array &n, PyObject *obj,
-                              PyObject *access);
+PYDYND_API void array_init_from_pyobject(dynd::nd::array &n, PyObject *obj,
+                                         PyObject *dt, bool uniform,
+                                         PyObject *access);
+PYDYND_API void array_init_from_pyobject(dynd::nd::array &n, PyObject *obj,
+                                         PyObject *access);
 
-dynd::nd::array array_view(PyObject *obj, PyObject *type, PyObject *access);
-dynd::nd::array array_asarray(PyObject *obj, PyObject *access);
+PYDYND_API dynd::nd::array array_view(PyObject *obj, PyObject *type,
+                                      PyObject *access);
+PYDYND_API dynd::nd::array array_asarray(PyObject *obj, PyObject *access);
 
-dynd::nd::array array_eval(const dynd::nd::array &n, PyObject *ectx);
+PYDYND_API dynd::nd::array array_eval(const dynd::nd::array &n, PyObject *ectx);
 dynd::nd::array array_eval_copy(const dynd::nd::array &n, PyObject *access,
                                 PyObject *ectx);
 
-dynd::nd::array array_zeros(const dynd::ndt::type &d, PyObject *access);
-dynd::nd::array array_zeros(PyObject *shape, const dynd::ndt::type &d,
-                            PyObject *access);
+PYDYND_API dynd::nd::array array_zeros(const dynd::ndt::type &d,
+                                       PyObject *access);
+PYDYND_API dynd::nd::array
+array_zeros(PyObject *shape, const dynd::ndt::type &d, PyObject *access);
 
-dynd::nd::array array_ones(const dynd::ndt::type &d, PyObject *access);
-dynd::nd::array array_ones(PyObject *shape, const dynd::ndt::type &d,
-                           PyObject *access);
+PYDYND_API dynd::nd::array array_ones(const dynd::ndt::type &d,
+                                      PyObject *access);
+PYDYND_API dynd::nd::array array_ones(PyObject *shape, const dynd::ndt::type &d,
+                                      PyObject *access);
 
-dynd::nd::array array_full(const dynd::ndt::type &d, PyObject *value,
-                           PyObject *access);
-dynd::nd::array array_full(PyObject *shape, const dynd::ndt::type &d,
-                           PyObject *value, PyObject *access);
+PYDYND_API dynd::nd::array array_full(const dynd::ndt::type &d, PyObject *value,
+                                      PyObject *access);
+PYDYND_API dynd::nd::array array_full(PyObject *shape, const dynd::ndt::type &d,
+                                      PyObject *value, PyObject *access);
 
-dynd::nd::array array_empty(const dynd::ndt::type &d, PyObject *access);
-dynd::nd::array array_empty(PyObject *shape, const dynd::ndt::type &d,
-                            PyObject *access);
+PYDYND_API dynd::nd::array array_empty(const dynd::ndt::type &d,
+                                       PyObject *access);
+PYDYND_API dynd::nd::array
+array_empty(PyObject *shape, const dynd::ndt::type &d, PyObject *access);
 
 inline dynd::nd::array array_empty_like(const dynd::nd::array &n)
 {
@@ -91,8 +97,8 @@ inline dynd::nd::array array_empty_like(const dynd::nd::array &n,
   return dynd::nd::empty_like(n, d);
 }
 
-dynd::nd::array array_memmap(PyObject *filename, PyObject *begin, PyObject *end,
-                             PyObject *access);
+PYDYND_API dynd::nd::array array_memmap(PyObject *filename, PyObject *begin,
+                                        PyObject *end, PyObject *access);
 
 inline bool array_is_c_contiguous(const dynd::nd::array &n)
 {
@@ -148,13 +154,13 @@ inline std::string array_repr(const dynd::nd::array &n)
   return ss.str();
 }
 
-PyObject *array_str(const dynd::nd::array &n);
-PyObject *array_unicode(const dynd::nd::array &n);
-PyObject *array_index(const dynd::nd::array &n);
-PyObject *array_nonzero(const dynd::nd::array &n);
-PyObject *array_int(const dynd::nd::array &n);
-PyObject *array_float(const dynd::nd::array &n);
-PyObject *array_complex(const dynd::nd::array &n);
+PYDYND_API PyObject *array_str(const dynd::nd::array &n);
+PYDYND_API PyObject *array_unicode(const dynd::nd::array &n);
+PYDYND_API PyObject *array_index(const dynd::nd::array &n);
+PYDYND_API PyObject *array_nonzero(const dynd::nd::array &n);
+PYDYND_API PyObject *array_int(const dynd::nd::array &n);
+PYDYND_API PyObject *array_float(const dynd::nd::array &n);
+PYDYND_API PyObject *array_complex(const dynd::nd::array &n);
 
 inline std::string array_debug_print(const dynd::nd::array &n)
 {
@@ -163,48 +169,52 @@ inline std::string array_debug_print(const dynd::nd::array &n)
   return ss.str();
 }
 
-bool array_contains(const dynd::nd::array &n, PyObject *x);
+PYDYND_API bool array_contains(const dynd::nd::array &n, PyObject *x);
 
-dynd::nd::array array_cast(const dynd::nd::array &n, const dynd::ndt::type &dt);
+PYDYND_API dynd::nd::array array_cast(const dynd::nd::array &n,
+                                      const dynd::ndt::type &dt);
 
-dynd::nd::array array_ucast(const dynd::nd::array &n, const dynd::ndt::type &dt,
-                            intptr_t replace_ndim);
+PYDYND_API dynd::nd::array array_ucast(const dynd::nd::array &n,
+                                       const dynd::ndt::type &dt,
+                                       intptr_t replace_ndim);
 
 PyObject *array_adapt(PyObject *a, PyObject *tp_obj, PyObject *adapt_op);
 
-PyObject *array_get_shape(const dynd::nd::array &n);
+PYDYND_API PyObject *array_get_shape(const dynd::nd::array &n);
 
-PyObject *array_get_strides(const dynd::nd::array &n);
+PYDYND_API PyObject *array_get_strides(const dynd::nd::array &n);
 
 bool array_is_scalar(const dynd::nd::array &n);
 
 /**
  * Implementation of __getitem__ for the wrapped array object.
  */
-dynd::nd::array array_getitem(const dynd::nd::array &n, PyObject *subscript);
+PYDYND_API dynd::nd::array array_getitem(const dynd::nd::array &n,
+                                         PyObject *subscript);
 
 /**
  * Implementation of __setitem__ for the wrapped dynd array object.
  */
-void array_setitem(const dynd::nd::array &n, PyObject *subscript,
-                   PyObject *value);
+PYDYND_API void array_setitem(const dynd::nd::array &n, PyObject *subscript,
+                              PyObject *value);
 
 /**
  * Implementation of nd.range().
  */
-dynd::nd::array array_range(PyObject *start, PyObject *stop, PyObject *step,
-                            PyObject *dt);
+PYDYND_API dynd::nd::array array_range(PyObject *start, PyObject *stop,
+                                       PyObject *step, PyObject *dt);
 
 /**
  * Implementation of nd.linspace().
  */
-dynd::nd::array array_linspace(PyObject *start, PyObject *stop, PyObject *count,
-                               PyObject *dt);
+PYDYND_API dynd::nd::array array_linspace(PyObject *start, PyObject *stop,
+                                          PyObject *count, PyObject *dt);
 
 /**
  * Implementation of nd.fields().
  */
-dynd::nd::array nd_fields(const dynd::nd::array &n, PyObject *field_list);
+PYDYND_API dynd::nd::array nd_fields(const dynd::nd::array &n,
+                                     PyObject *field_list);
 
 inline const char *array_access_flags_string(const dynd::nd::array &n)
 {

--- a/dynd/include/arrfunc_from_pyfunc.hpp
+++ b/dynd/include/arrfunc_from_pyfunc.hpp
@@ -9,11 +9,14 @@
 
 #include <dynd/func/arrfunc.hpp>
 
+#include "config.hpp"
+
 namespace pydynd {
 namespace nd {
   namespace functional {
 
-    dynd::nd::arrfunc apply(PyObject *pyfunc, const dynd::ndt::type &proto);
+    PYDYND_API dynd::nd::arrfunc apply(PyObject *pyfunc,
+                                       const dynd::ndt::type &proto);
 
     inline dynd::nd::arrfunc apply(PyObject *pyfunc, PyObject *proto)
     {

--- a/dynd/include/arrfunc_functions.hpp
+++ b/dynd/include/arrfunc_functions.hpp
@@ -15,6 +15,7 @@
 
 #include <dynd/func/arrfunc.hpp>
 
+#include "config.hpp"
 #include "array_from_py.hpp"
 #include "array_as_py.hpp"
 #include "array_as_numpy.hpp"
@@ -41,10 +42,10 @@ struct WArrFunc {
   // This is array_placement_wrapper in Cython-land
   dynd::nd::arrfunc v;
 };
-void init_w_arrfunc_typeobject(PyObject *type);
+PYDYND_API void init_w_arrfunc_typeobject(PyObject *type);
 
-PyObject *arrfunc_call(PyObject *af_obj, PyObject *args_obj, PyObject *kwds_obj,
-                       PyObject *ectx_obj);
+PYDYND_API PyObject *arrfunc_call(PyObject *af_obj, PyObject *args_obj,
+                                  PyObject *kwds_obj, PyObject *ectx_obj);
 
 PyObject *arrfunc_rolling_apply(PyObject *func_obj, PyObject *arr_obj,
                                 PyObject *window_size_obj, PyObject *ectx_obj);

--- a/dynd/include/config.hpp
+++ b/dynd/include/config.hpp
@@ -5,14 +5,14 @@
 #include <dynd/config.hpp>
 #include <dynd/array.hpp>
 
-namespace pydynd {
-
-namespace nd {
-
-} // namespace pydynd::nd
-
-namespace ndt {
-
-} // namespace pydynd::ndt
-
-} // namespace pydynd
+#if defined(_WIN32)
+#if defined(PYDYND_EXPORT)
+// Building the library
+#define PYDYND_API __declspec(dllexport)
+#else
+// Importing the library
+#define PYDYND_API __declspec(dllimport)
+#endif
+#else
+#define PYDYND_API
+#endif

--- a/dynd/include/copy_to_numpy_arrfunc.hpp
+++ b/dynd/include/copy_to_numpy_arrfunc.hpp
@@ -10,6 +10,8 @@
 #include <dynd/kernels/base_virtual_kernel.hpp>
 #include <dynd/func/arrfunc.hpp>
 
+#include "config.hpp"
+
 namespace pydynd {
 
 /**

--- a/dynd/include/ctypes_interop.hpp
+++ b/dynd/include/ctypes_interop.hpp
@@ -9,7 +9,7 @@
 #ifndef _DYND__CTYPES_INTEROP_HPP_
 #define _DYND__CTYPES_INTEROP_HPP_
 
-#include <Python.h>
+#include "config.hpp"
 
 #include <dynd/type.hpp>
 #include <dynd/codegen/calling_conventions.hpp>

--- a/dynd/include/eval_context_functions.hpp
+++ b/dynd/include/eval_context_functions.hpp
@@ -15,12 +15,14 @@
 
 #include <dynd/eval/eval_context.hpp>
 
+#include "config.hpp"
+
 namespace pydynd {
 
 /**
  * This is the typeobject and struct of w_eval_context from Cython.
  */
-extern PyTypeObject *WEvalContext_Type;
+PYDYND_API extern PyTypeObject *WEvalContext_Type;
 inline bool WEvalContext_CheckExact(PyObject *obj)
 {
   return Py_TYPE(obj) == WEvalContext_Type;
@@ -34,7 +36,7 @@ struct WEvalContext {
   const dynd::eval::eval_context *ectx;
   bool own_ectx;
 };
-void init_w_eval_context_typeobject(PyObject *type);
+PYDYND_API void init_w_eval_context_typeobject(PyObject *type);
 
 /**
  * Makes a copy of an eval context, owned by a WEvalContext.
@@ -71,19 +73,19 @@ inline const dynd::eval::eval_context *eval_context_from_pyobj(PyObject *obj)
  * in the keyword args. This returns unprotected memory allocated
  * by 'new', to be wrapped up in a WEvalContext wrapper.
  */
-dynd::eval::eval_context *new_eval_context(PyObject *kwargs);
+PYDYND_API dynd::eval::eval_context *new_eval_context(PyObject *kwargs);
 
 /**
  * Accepts parameters like new_eval_context, but changes the
  * default eval context in place.
  */
-void modify_default_eval_context(PyObject *kwargs);
+PYDYND_API void modify_default_eval_context(PyObject *kwargs);
 
-PyObject *get_eval_context_errmode(PyObject *ectx_obj);
-PyObject *get_eval_context_cuda_device_errmode(PyObject *ectx_obj);
-PyObject *get_eval_context_date_parse_order(PyObject *ectx_obj);
-PyObject *get_eval_context_century_window(PyObject *ectx_obj);
-PyObject *get_eval_context_repr(PyObject *ectx_obj);
+PYDYND_API PyObject *get_eval_context_errmode(PyObject *ectx_obj);
+PYDYND_API PyObject *get_eval_context_cuda_device_errmode(PyObject *ectx_obj);
+PYDYND_API PyObject *get_eval_context_date_parse_order(PyObject *ectx_obj);
+PYDYND_API PyObject *get_eval_context_century_window(PyObject *ectx_obj);
+PYDYND_API PyObject *get_eval_context_repr(PyObject *ectx_obj);
 
 } // namespace pydynd
 

--- a/dynd/include/exception_translation.hpp
+++ b/dynd/include/exception_translation.hpp
@@ -8,11 +8,13 @@
 
 #include <Python.h>
 
+#include "config.hpp"
+
 namespace pydynd {
 
-void translate_exception();
+PYDYND_API void translate_exception();
 
-void set_broadcast_exception(PyObject *e);
+PYDYND_API void set_broadcast_exception(PyObject *e);
 
 } // namespace pydynd
 

--- a/dynd/include/gfunc_callable_functions.hpp
+++ b/dynd/include/gfunc_callable_functions.hpp
@@ -14,6 +14,8 @@
 
 #include <sstream>
 
+#include "config.hpp"
+
 namespace pydynd {
 
 struct array_callable_wrapper {
@@ -39,13 +41,13 @@ struct WArrayCallable {
   // This is array_placement_wrapper in Cython-land
   array_callable_wrapper v;
 };
-void init_w_array_callable_typeobject(PyObject *type);
+PYDYND_API void init_w_array_callable_typeobject(PyObject *type);
 
 /**
  * This calls the callable in the array_callable_wrapper, which was
  * returned as a property of an array.
  */
-PyObject *array_callable_call(const array_callable_wrapper &ncw, PyObject *args,
+PYDYND_API PyObject *array_callable_call(const array_callable_wrapper &ncw, PyObject *args,
                               PyObject *kwargs);
 
 struct _type_callable_wrapper {
@@ -71,12 +73,12 @@ struct WTypeCallable {
   // This is _type_placement_wrapper in Cython-land
   _type_callable_wrapper v;
 };
-void init_w__type_callable_typeobject(PyObject *type);
+PYDYND_API void init_w__type_callable_typeobject(PyObject *type);
 /**
  * This calls the callable in the _type_callable_wrapper, which was
  * returned as a property of a dynd type.
  */
-PyObject *_type_callable_call(const _type_callable_wrapper &ccw, PyObject *args,
+PYDYND_API PyObject *_type_callable_call(const _type_callable_wrapper &ccw, PyObject *args,
                               PyObject *kwargs);
 
 /**
@@ -92,21 +94,24 @@ void add__type_names_to_dir_dict(const dynd::ndt::type &dt, PyObject *dict);
 /**
  * Retrieves a dynamic property from the dynd type as a Python object.
  */
-PyObject *get__type_dynamic_property(const dynd::ndt::type &dt, PyObject *name);
+PYDYND_API PyObject *get__type_dynamic_property(const dynd::ndt::type &dt,
+                                                PyObject *name);
 
 /**
  * Adds all the dynamic names exposed by the array to the provided dict.
  */
-void add_array_names_to_dir_dict(const dynd::nd::array &n, PyObject *dict);
+PYDYND_API void add_array_names_to_dir_dict(const dynd::nd::array &n,
+                                            PyObject *dict);
 /**
  * Retrieves a dynamic property from the nd::array.
  */
-PyObject *get_array_dynamic_property(const dynd::nd::array &n, PyObject *name);
+PYDYND_API PyObject *get_array_dynamic_property(const dynd::nd::array &n,
+                                                PyObject *name);
 /**
  * Sets a dynamic property of the nd::array.
  */
-void set_array_dynamic_property(const dynd::nd::array &n, PyObject *name,
-                                PyObject *value);
+PYDYND_API void set_array_dynamic_property(const dynd::nd::array &n,
+                                           PyObject *name, PyObject *value);
 
 /**
  * Calls the callable with the single dynd type parameter

--- a/dynd/include/git_version.hpp
+++ b/dynd/include/git_version.hpp
@@ -6,11 +6,13 @@
 #ifndef _PYDYND__GIT_VERSION_HPP_
 #define _PYDYND__GIT_VERSION_HPP_
 
+#include "config.hpp"
+
 namespace pydynd {
 // These are defined in git_version.cpp, generated from
 // git_version.cpp.in by the CMake build configuration.
-extern const char dynd_python_git_sha1[];
-extern const char dynd_python_version_string[];
+PYDYND_API extern const char dynd_python_git_sha1[];
+PYDYND_API extern const char dynd_python_version_string[];
 } // namespace pydynd
 
 #endif // _PYDYND__GIT_VERSION_HPP_

--- a/dynd/include/init.hpp
+++ b/dynd/include/init.hpp
@@ -6,9 +6,11 @@
 #ifndef DYND__INIT_HPP
 #define DYND__INIT_HPP
 
+#include "config.hpp"
+
 namespace pydynd {
 
-void pydynd_init();
+PYDYND_API void pydynd_init();
 
 } // namespace pydynd
 

--- a/dynd/include/numpy_interop.hpp
+++ b/dynd/include/numpy_interop.hpp
@@ -46,6 +46,8 @@
 #include <numpy/ndarrayobject.h>
 #include <numpy/ufuncobject.h>
 
+#include "config.hpp"
+
 #ifndef NPY_DATETIME_NAT
 #define NPY_DATETIME_NAT NPY_MIN_INT64
 #endif
@@ -125,7 +127,7 @@ void fill_arrmeta_from_numpy_dtype(const dynd::ndt::type &tp, PyArray_Descr *d,
  *
  * \param tp  The dynd type to convert.
  */
-PyArray_Descr *numpy_dtype_from__type(const dynd::ndt::type &tp);
+PYDYND_API PyArray_Descr *numpy_dtype_from__type(const dynd::ndt::type &tp);
 
 /** Small helper for cython parameter */
 inline PyObject *numpy_dtype_obj_from__type(const dynd::ndt::type &tp)
@@ -140,8 +142,8 @@ inline PyObject *numpy_dtype_obj_from__type(const dynd::ndt::type &tp)
  * \param tp  The dynd type to convert.
  * \param arrmeta  The arrmeta for the dynd type.
  */
-PyArray_Descr *numpy_dtype_from__type(const dynd::ndt::type &tp,
-                                         const char *arrmeta);
+PYDYND_API PyArray_Descr *numpy_dtype_from__type(const dynd::ndt::type &tp,
+                                                 const char *arrmeta);
 
 /**
  * Converts a pytypeobject for a n`umpy scalar

--- a/dynd/include/py_lowlevel_api.hpp
+++ b/dynd/include/py_lowlevel_api.hpp
@@ -8,6 +8,7 @@
 
 #include <dynd/lowlevel_api.hpp>
 
+#include "config.hpp"
 #include "array_functions.hpp"
 #include "type_functions.hpp"
 
@@ -61,6 +62,6 @@ struct py_lowlevel_api_t {
 /**
  * Returns a pointer to the static low level API structure.
  */
-extern "C" const void *dynd_get_py_lowlevel_api();
+extern "C" PYDYND_API const void *dynd_get_py_lowlevel_api();
 
 #endif // _DYND__PY_LOWLEVEL_API_HPP_

--- a/dynd/include/type_functions.hpp
+++ b/dynd/include/type_functions.hpp
@@ -16,6 +16,8 @@
 #include <dynd/type.hpp>
 #include <dynd/string_encodings.hpp>
 
+#include "config.hpp"
+
 namespace pydynd {
 
 /**
@@ -37,7 +39,7 @@ struct WType {
   dynd::ndt::type v;
 };
 
-void init_w_type_typeobject(PyObject *type);
+PYDYND_API void init_w_type_typeobject(PyObject *type);
 
 inline PyObject *wrap__type(const dynd::ndt::type &d)
 {
@@ -75,73 +77,72 @@ inline std::string _type_str(const dynd::ndt::type &d)
   return ss.str();
 }
 
-std::string _type_repr(const dynd::ndt::type &d);
+PYDYND_API std::string _type_repr(const dynd::ndt::type &d);
 
-PyObject *_type_get_shape(const dynd::ndt::type &d);
+PYDYND_API PyObject *_type_get_shape(const dynd::ndt::type &d);
 
 /**
  * Returns the kind of the ndt::type, as a Python string.
  */
-PyObject *_type_get_kind(const dynd::ndt::type &d);
+PYDYND_API PyObject *_type_get_kind(const dynd::ndt::type &d);
 
 /**
  * Returns the type id of the ndt::type, as a Python string.
  */
-PyObject *_type_get_type_id(const dynd::ndt::type &d);
+PYDYND_API PyObject *_type_get_type_id(const dynd::ndt::type &d);
 
 /**
  * Converts a Python type, numpy dtype, or string
  * into an ndt::type. This raises an error if given an object
  * which contains values, it is for type-like things only.
  */
-dynd::ndt::type make__type_from_pyobject(PyObject *obj);
+PYDYND_API dynd::ndt::type make__type_from_pyobject(PyObject *obj);
 
 /**
  * Creates a convert type.
  */
-dynd::ndt::type dynd_make_convert_type(const dynd::ndt::type &to_tp,
+PYDYND_API dynd::ndt::type dynd_make_convert_type(const dynd::ndt::type &to_tp,
                                        const dynd::ndt::type &from_tp);
 
 /**
  * Creates a view type.
  */
-dynd::ndt::type dynd_make_view_type(const dynd::ndt::type &value_type,
-                                    const dynd::ndt::type &operand_type);
+PYDYND_API dynd::ndt::type
+dynd_make_view_type(const dynd::ndt::type &value_type,
+                    const dynd::ndt::type &operand_type);
 
 /**
  * Creates a fixed-sized string type.
  */
-dynd::ndt::type dynd_make_fixed_string_type(intptr_t size,
-                                            PyObject *encoding_obj);
+PYDYND_API dynd::ndt::type dynd_make_fixed_string_type(intptr_t size,
+                                                       PyObject *encoding_obj);
 
 /**
  * Creates a blockref string type.
  */
-dynd::ndt::type dynd_make_string_type(PyObject *encoding_obj);
+PYDYND_API dynd::ndt::type dynd_make_string_type(PyObject *encoding_obj);
 
 /**
  * Creates a blockref pointer type.
  */
-dynd::ndt::type dynd_make_pointer_type(const dynd::ndt::type &target_tp);
+PYDYND_API dynd::ndt::type
+dynd_make_pointer_type(const dynd::ndt::type &target_tp);
 
-dynd::ndt::type dynd_make_struct_type(PyObject *field_types,
-                                      PyObject *field_names);
-dynd::ndt::type dynd_make_cstruct_type(PyObject *field_types,
-                                       PyObject *field_names);
-dynd::ndt::type dynd_make_fixed_dim_type(PyObject *shape,
-                                         const dynd::ndt::type &element_tp);
-dynd::ndt::type dynd_make_cfixed_dim_type(PyObject *shape,
-                                          const dynd::ndt::type &element_tp,
-                                          PyObject *axis_perm);
+PYDYND_API dynd::ndt::type dynd_make_struct_type(PyObject *field_types,
+                                                 PyObject *field_names);
+
+PYDYND_API dynd::ndt::type
+dynd_make_fixed_dim_type(PyObject *shape, const dynd::ndt::type &element_tp);
 
 /**
  * Implementation of __getitem__ for the wrapped dynd type object.
  */
-dynd::ndt::type _type_getitem(const dynd::ndt::type &d, PyObject *subscript);
+PYDYND_API dynd::ndt::type _type_getitem(const dynd::ndt::type &d,
+                                         PyObject *subscript);
 
-PyObject *_type_array_property_names(const dynd::ndt::type &d);
+PYDYND_API PyObject *_type_array_property_names(const dynd::ndt::type &d);
 
-void init_type_functions();
+PYDYND_API void init_type_functions();
 
 } // namespace pydynd
 

--- a/dynd/include/utility_functions.hpp
+++ b/dynd/include/utility_functions.hpp
@@ -14,6 +14,8 @@
 
 #include <dynd/type.hpp>
 
+#include "config.hpp"
+
 namespace dynd {
 // Forward declaration
 struct arrfunc_type_data;

--- a/dynd/src/init.cpp
+++ b/dynd/src/init.cpp
@@ -3,7 +3,8 @@
 // BSD 2-Clause License, see LICENSE.txt
 //
 
-#include <Python.h>
+#define NUMPY_IMPORT_ARRAY
+#include "numpy_interop.hpp"
 
 #include "init.hpp"
 #include "ctypes_interop.hpp"
@@ -20,6 +21,7 @@ static void pydynd_cleanup() { dynd::libdynd_cleanup(); }
 
 void pydynd::pydynd_init()
 {
+  import_numpy();
   dynd::libdynd_init();
   atexit(pydynd_cleanup);
   pydynd::init_type_functions();


### PR DESCRIPTION
Main changes:

Add PYDYND_API symbol to indicate which functions should be exported by the .dll.

The NumPy symbols were missing, causing link errors. Added the import_numpy to pydynd_init.