### PR TITLE
Added some options to setup.py 

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -54,7 +54,7 @@ install:
   - SET PATH=C:\Py;C:\Py\Scripts;%PATH%
 
 build_script:
-  - C:\Py\python setup.py bdist_wheel --msvc %MSVC%
+  - C:\Py\python setup.py bdist_wheel --msvc=%MSVC%
 
 test_script:
   - cd dist
@@ -65,5 +65,3 @@ test_script:
 
 artifacts:
   - path: dist\*
-
-

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, Extension
 
 import os, sys
 from os import chdir, getcwd
-from os.path import abspath, dirname, split
+from os.path import abspath, dirname, split, normcase
 
 import re
 
@@ -55,11 +55,9 @@ class cmake_build_ext(build_ext):
 
     # Detect if we built elsewhere
     if os.path.isfile('CMakeCache.txt'):
-        cachefile = open('CMakeCache.txt', 'r')
-        cachedir = re.search('CMAKE_CACHEFILE_DIR:INTERNAL=(.*)', cachefile.read()).group(1)
-        cachefile.close()
-
-        if (cachedir != build_temp):
+        with open('CMakeCache.txt', 'r') as cachefile:
+            cachedir = re.search('CMAKE_CACHEFILE_DIR:INTERNAL=(.*)', cachefile.read()).group(1).replace("\\", '/')
+        if not normcase(cachedir.replace('\\', '/')) == normcase(build_temp.replace('\\', '/')):
             return
 
     pyexe_option = '-DPYTHON_EXECUTABLE=%s' % sys.executable


### PR DESCRIPTION
This allows users to specify the executable path and also allows them to select the cmake generator used. This, combined with https://github.com/libdynd/libdynd/pull/482 was enough to get the setup to run on my mingw build. The build still fails due to a linker error that claims `void DyND_PyWrapper_Type<dynd::nd::array>` was defined multiple times, but this is progress in the right direction.
It would be fairly simple to allow users to specify a variety of different flags to cmake, but, since the compiler and compiler flags are all properly drawn from the build environment, that seemed excessive, so I opted to just add these two options.