### PR TITLE
Skip installing numpy since the default version is recent enough.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,6 @@ install:
   - export CXX=g++-4.7
   # Install dependencies
   - travis_retry pip install --install-option="--no-cython-compile" Cython==0.21
-  - travis_retry pip install numpy
   # Put libdynd sources in the right place so they are built with dynd-python.
   - mkdir libraries
   - pushd libraries


### PR DESCRIPTION
I figured that, in light of https://github.com/libdynd/libdynd/pull/487, it would make sense to do that here too. This should hopefully speed up the build even more.