### PR TITLE
Added extra exception catching branch

### DIFF
--- a/dynd/src/exception_translation.cpp
+++ b/dynd/src/exception_translation.cpp
@@ -104,6 +104,9 @@ void pydynd::translate_exception()
     // redundantly also catch runtime_error.
     PyErr_SetString(PyExc_RuntimeError, exn.what());
   }
+  catch (const dynd::dynd_exception &exn) {
+    PyErr_SetString(PyExc_RuntimeError, exn.what());
+  }
   catch (const std::exception &exn) {
     PyErr_SetString(PyExc_RuntimeError, exn.what());
   }


### PR DESCRIPTION
This fixes the test failure from https://github.com/libdynd/libdynd/pull/536. Generic `dynd::dynd_exception` instances weren't getting caught since they are no longer subclasses of `std::exception`.