### PR TITLE
Match exception changes in libdynd

### DIFF
--- a/dynd/src/array_as_pep3118.cpp
+++ b/dynd/src/array_as_pep3118.cpp
@@ -419,6 +419,19 @@ int pydynd::array_getbuffer_pep3118(PyObject *ndo, Py_buffer *buffer, int flags)
     PyErr_SetString(PyExc_BufferError, e.what());
     return -1;
   }
+  catch (const dynd::dynd_exception &e) {
+    // Numpy likes to hide these errors and repeatedly try again, so it's useful
+    // to see what's happening
+    // cout << "ERROR " << e.what() << endl;
+    Py_DECREF(ndo);
+    buffer->obj = NULL;
+    if (buffer->internal != NULL) {
+      free(buffer->internal);
+      buffer->internal = NULL;
+    }
+    PyErr_SetString(PyExc_BufferError, e.what());
+    return -1;
+  }
 }
 
 int pydynd::array_releasebuffer_pep3118(PyObject *ndo, Py_buffer *buffer)
@@ -431,6 +444,10 @@ int pydynd::array_releasebuffer_pep3118(PyObject *ndo, Py_buffer *buffer)
     return 0;
   }
   catch (const std::exception &e) {
+    PyErr_SetString(PyExc_BufferError, e.what());
+    return -1;
+  }
+  catch (const dynd::dynd_exception &e) {
     PyErr_SetString(PyExc_BufferError, e.what());
     return -1;
   }


### PR DESCRIPTION
This fixes the previous issues with uncaught c++ exceptions getting thrown during the tests. This PR matches dynd-python to https://github.com/libdynd/libdynd/pull/538.