### PR TITLE
Fix install instructions to setup.py in

### DIFF
--- a/BUILD_INSTALL.md
+++ b/BUILD_INSTALL.md
@@ -55,7 +55,8 @@ to the cmake command.
   <...>
   ~/dynd-python/build $ make
   <...>
-  ~/dynd-python/build $ sudo make install
+  ~/dynd-python/build $ cd ..
+  ~/dynd-python $ python setup.py install
   ```
 
   If you want to control where the Python module goes, add


### PR DESCRIPTION
In part 5 of the build from source dynd-python is said to require a `sudo make install` step, but https://github.com/libdynd/dynd-python/issues/370#issuecomment-143808702 suggests it should be `python setup.py install`.

Also — this eliminates sudo from at least one step (which should be fine)? I'll change it to include sudo if that can be expected to fail in most situations.