### PR TITLE
Removals

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,10 @@ else()
     target_link_libraries(pydynd libdynd)
 endif()
 
+foreach(pyx_api_file dynd/config.pyx dynd/nd/array.pyx dynd/nd/callable.pyx dynd/ndt/type.pyx)
+    set_source_files_properties(${pyx_api_file} PROPERTIES CYTHON_API 1)
+endforeach(pyx_api_file)
+
 foreach(module config eval_context ndt.type ndt.json nd.array nd.callable nd.functional nd.registry)
     string(REPLACE "." ";" directories ${module})
     list(GET directories -1 module_name)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ include_directories(
     dynd/include
     ${CMAKE_CURRENT_BINARY_DIR}/dynd
     dynd
+    ${CMAKE_CURRENT_BINARY_DIR}
     )
 
 if(DYND_CUDA)

--- a/cmake/UseCython.cmake
+++ b/cmake/UseCython.cmake
@@ -110,8 +110,16 @@ function( compile_pyx _name pyx_target_name generated_files pyx_file)
       endif()
   endif()
 
-  # Determining generated file name.
-  set( _generated_files "${_name}.${extension}" )
+  # Determining generated file names.
+  get_source_file_property( property_is_public ${pyx_file} CYTHON_PUBLIC )
+  get_source_file_property( property_is_api ${pyx_file} CYTHON_API )
+  if( ${property_is_api} )
+      set( _generated_files "${_name}.${extension}" "${_name}.h" "${name}_api.h")
+  elseif( ${property_is_public} )
+      set( _generated_files "${_name}.${extension}" "${_name}.h")
+  else()
+      set( _generated_files "${_name}.${extension}")
+  endif()
   set_source_files_properties( ${_generated_files} PROPERTIES GENERATED TRUE )
   set( ${generated_files} ${_generated_files} PARENT_SCOPE )
 

--- a/cmake/UseCython.cmake
+++ b/cmake/UseCython.cmake
@@ -127,7 +127,7 @@ function( compile_pyx _name pyx_target_name generated_files pyx_file)
   add_custom_target(${pyx_target_name}
     COMMAND ${CYTHON_EXECUTABLE} ${cxx_arg} ${include_directory_arg}
     ${annotate_arg} ${no_docstrings_arg} ${cython_debug_arg} ${CYTHON_FLAGS}
-    --output-file ${_generated_files} ${pyx_location}
+    --output-file "${_name}.${extension}" ${pyx_location}
     DEPENDS ${pyx_location}
     # do not specify byproducts for now since they don't work with the older
     # version of cmake available in the apt repositories.


### PR DESCRIPTION
This builds up the last bit of infrastructure needed to use the "api" headers generated by Cython from within the C++ modules. One issue should eventually be sorted out on the Cython end: the api headers currently can't be used by headers that are, in turn, included into the C++ files from the module that created them. The way the ifdef guards are currently set up makes it so that the headers do nothing when included, even indirectly, inside the source for a Cython-built module.