### PR TITLE
Remove initialization function for BroadcastError.

### DIFF
--- a/dynd/config.pxd
+++ b/dynd/config.pxd
@@ -1,5 +1,4 @@
 cdef:
     void translate_exception()
-    void set_broadcast_exception(object)
 
 cdef api object DyND_PyExc_BroadcastError

--- a/dynd/config.pyx
+++ b/dynd/config.pyx
@@ -1,13 +1,13 @@
 from .cpp.config cimport dynd_version_string, dynd_git_sha1
+from cpython.ref cimport PyObject
 
-cdef extern from 'exception_translation.hpp' namespace 'pydynd':
+
+cdef extern from 'exception_translation.hpp':
     void _translate_exception "pydynd::translate_exception"()
-    void _set_broadcast_exception "pydynd::set_broadcast_exception"(object)
+    PyObject* DyND_BroadcastException
 
 cdef void translate_exception():
     _translate_exception()
-cdef void set_broadcast_exception(object e):
-    _set_broadcast_exception(e)
 
 cdef extern from 'do_import_array.hpp':
     pass
@@ -37,10 +37,9 @@ import_numpy()
 class BroadcastError(Exception):
     pass
 
-cdef api object DyND_PyExc_BroadcastError = BroadcastError
+# Used in exception translation header.
+# It is forward-declared there and then set when this module is initialized.
+DyND_BroadcastException = <PyObject*>BroadcastError
 
 # Initialize ctypes C level interop data
 pydynd_init()
-
-# Register all the exception objects with the exception translator
-set_broadcast_exception(BroadcastError)

--- a/dynd/include/exception_translation.hpp
+++ b/dynd/include/exception_translation.hpp
@@ -13,15 +13,13 @@
 
 #include "dynd/array.hpp"
 
-namespace {
-PyObject *BroadcastException = NULL;
-} // anonymous namespace
+// This header must only be used inside the config module because otherwise
+// this variable is not properly initialized.
+static PyObject *DyND_BroadcastException;
 
 namespace pydynd {
 
-void set_broadcast_exception(PyObject *e) { BroadcastException = e; }
-
-inline void translate_exception()
+static inline void translate_exception()
 {
   try {
     // let any Python exn pass through, otherwise translate the C++ one
@@ -30,7 +28,7 @@ inline void translate_exception()
     }
   }
   catch (const dynd::broadcast_error &exn) {
-    PyErr_SetString(BroadcastException, exn.message());
+    PyErr_SetString(DyND_BroadcastException, exn.message());
   }
   catch (const dynd::too_many_indices &exn) {
     PyErr_SetString(PyExc_IndexError, exn.message());


### PR DESCRIPTION
As a part of the restructuring, I'm trying to make it so that all initialization happens implicitly as a part of each Python modules initialization routine.