### PR TITLE
Refine libdynd.dll search order.

### DIFF
--- a/dynd/__init__.py
+++ b/dynd/__init__.py
@@ -1,28 +1,54 @@
 import os
 if os.name == 'nt':
     # Manually load dlls before loading the extension modules.
-    # TODO: template a file using cmake that stores the location of the
-    # libdynd library used during compilation.
-    import os.path
-    import sys
     from ctypes import cdll
-    is_64_bit = sys.maxsize > 2**32
-    is_32_on_64_bit = (is_64_bit and not
-                       os.environ['PROCESSOR_ARCHITECTURE'].endswith('64'))
-    pydynd_dir = os.path.dirname(os.path.realpath(__file__))
-    if not os.path.isfile(os.path.join(pydynd_dir, 'libdynd.dll')):
+    import os.path
+    # If libdynd.dll is already on the path, use it.
+    try:
+        # The default dll search order should give precedence to copies of
+        # libdynd in the same directory as this file.
+        cdll.LoadLibrary('libdynd.dll')
+    except OSError:
+        # Try to load it from the Program Files directories where libdynd
+        # installs by default. This matches the search path for libdynd used
+        # in the CMake build for dynd-python.
+        import sys
+        is_64_bit = sys.maxsize > 2**32
+        processor_arch = os.environ.get('PROCESSOR_ARCHITECTURE')
+        err_str = ('Fallback search for libdynd.dll failed because the "{}" '
+                   'environment variable was not set. Please make sure that '
+                   'either libdynd is on the DLL search path or that it is '
+                   'in the default install directory and the runtime '
+                   'environment has the necessary system-specified '
+                   'environment variables properly set. On 64 bit Windows '
+                   'with 64 bit Python the needed variables are '
+                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles". On 64 bit '
+                   'Windows with 32 bit Python the needed variables are '
+                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles(x86)". On 32 '
+                   'bit Windows the needed variables are '
+                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles".')
+        if processor_arch is None:
+            raise RuntimeError(err_str.format('PROCESSOR_ARCHITECTURE'))
+        is_32_on_64_bit = (is_64_bit and not processor_arch.endswith('64'))
         if not is_32_on_64_bit:
-            libdynd_path = os.path.join(os.environ['ProgramFiles'], 'libdynd',
-                                        'lib', 'libdynd.dll')
+            prog_files = os.environ.get('ProgramFiles')
+            if prog_files is None:
+                raise RuntimeError(err_str.format('ProgramFiles'))
+            libdynd_path = os.path.join(prog_files, 'libdynd', 'lib',
+                                        'libdynd.dll')
             if os.path.isfile(libdynd_path):
                 cdll.LoadLibrary(libdynd_path)
         else:
-            libdynd_path = os.path.join(os.environ['ProgramFiles(x86)'],
-                                        'libdynd', 'lib', 'libdynd.dll')
+            prog_files = os.environ.get('ProgramFiles(x86)')
+            if prog_files is None:
+                raise RuntimeError(err_str.format('ProgramFiles(x86)'))
+            libdynd_path = os.path.join(prog_files, 'libdynd', 'lib',
+                                        'libdynd.dll')
             if os.path.isfile(libdynd_path):
                 cdll.LoadLibrary(libdynd_path)
-    else:
-        cdll.LoadLibrary(os.path.join(pydynd_dir, 'libdynd.dll'))
+    # Load libpydynd from current directory now that libdynd
+    # has been loaded.
+    pydynd_dir = os.path.dirname(os.path.realpath(__file__))
     cdll.LoadLibrary(os.path.join(pydynd_dir, 'pydynd.dll'))
 
 from .config import _dynd_version_string as __libdynd_version__, \


### PR DESCRIPTION
Give preference to dlls on the path over dlls in the default install
location.
Complain very loudly in the fallback search if the runtime environment
isn't sane enough to have various system default environment variables
set.