### PR TITLE
Remove type functions.

### DIFF
--- a/dynd/cpp/type.pxd
+++ b/dynd/cpp/type.pxd
@@ -21,7 +21,6 @@ cdef extern from 'dynd/type.hpp' namespace 'dynd::ndt' nogil:
         type get_canonical_type()
 
         map[string, callable] get_properties()
-        map[string, callable] get_functions()
 
         bool is_builtin()
         bool is_null()

--- a/dynd/ndt/type.pyx
+++ b/dynd/ndt/type.pyx
@@ -229,16 +229,10 @@ cdef class type(object):
             raise AttributeError(name)
 
         cdef _callable p
-        cdef map[string, _callable] functions
-        cdef _callable f
         cdef map[string, _callable] properties = self.v.get_properties()
         p = properties[name]
         if (not p.is_null()):
             return dynd_nd_array_from_cpp(p(self.v))
-        functions = self.v.get_functions()
-        f = functions[name]
-        if (not f.is_null()):
-            return dynd_nd_array_from_cpp(f(self.v))
 
         raise AttributeError(name)
 


### PR DESCRIPTION

This updates dynd to match https://github.com/libdynd/libdynd/pull/974.  The type functions appear to be unused, so I've removed them all.