### PR TITLE
Add generic exception handling block to exception translation routine.

### DIFF
--- a/dynd/include/exception_translation.hpp
+++ b/dynd/include/exception_translation.hpp
@@ -115,6 +115,11 @@ static inline void translate_exception()
   catch (const std::exception &exn) {
     PyErr_SetString(PyExc_RuntimeError, exn.what());
   }
+  catch (...) {
+    PyErr_SetString(
+        PyExc_RuntimeError,
+        "Conversion from C++ exception to Python exception failed!");
+  }
 }
 
 } // namespace pydynd


### PR DESCRIPTION
This at least prevents crashing the interpreter when an exception somehow gets through all the other layers of exception translation we have set up. Usually if something manages to get through all those other layers it indicates a toolchain problem or possibly a version mismatch between libdynd and dynd-python, but this lets us raise an error on the Python side of things anyway.