### PR TITLE
Update Python-specific callables to use the new declfunc template.

### DIFF
--- a/dynd/include/assign.hpp
+++ b/dynd/include/assign.hpp
@@ -19,6 +19,7 @@ PYDYND_API void assign_init();
 extern struct assign_to_pyarrayobject
     : dynd::nd::declfunc<assign_to_pyarrayobject> {
   static dynd::nd::callable make();
+  static dynd::nd::callable &get();
 } assign_to_pyarrayobject;
 
 void array_copy_to_numpy(PyArrayObject *dst_arr, const dynd::ndt::type &src_tp,

--- a/dynd/include/copy_from_numpy_arrfunc.hpp
+++ b/dynd/include/copy_from_numpy_arrfunc.hpp
@@ -32,6 +32,7 @@ namespace nd {
 
   extern struct copy_from_numpy : dynd::nd::declfunc<copy_from_numpy> {
     static dynd::nd::callable make();
+    static dynd::nd::callable &get();
   } copy_from_numpy;
 
   void array_copy_from_numpy(const dynd::ndt::type &dst_tp,

--- a/dynd/src/assign.cpp
+++ b/dynd/src/assign.cpp
@@ -24,7 +24,8 @@ PYDYND_API void assign_init()
       uint16_id, uint32_id, uint64_id, uint128_id, float16_id, float32_id,
       float64_id, complex_float32_id, complex_float64_id, bytes_id,
       fixed_bytes_id, string_id, fixed_string_id, option_id, type_id, tuple_id,
-      struct_id, fixed_dim_id, var_dim_id> type_ids;
+      struct_id, fixed_dim_id, var_dim_id>
+      type_ids;
 
   PyDateTime_IMPORT;
 
@@ -47,6 +48,12 @@ nd::callable assign_to_pyarrayobject::make()
 {
   return nd::functional::elwise(
       nd::callable::make<assign_to_pyarrayobject_kernel>());
+}
+
+nd::callable &assign_to_pyarrayobject::get()
+{
+  static nd::callable self = assign_to_pyarrayobject::make();
+  return self;
 }
 
 struct assign_to_pyarrayobject assign_to_pyarrayobject;

--- a/dynd/src/copy_from_numpy_arrfunc.cpp
+++ b/dynd/src/copy_from_numpy_arrfunc.cpp
@@ -6,15 +6,15 @@
 #include <Python.h>
 #include <datetime.h>
 
+#include "array_from_py_typededuction.hpp"
+#include "array_functions.hpp"
 #include "copy_from_numpy_arrfunc.hpp"
 #include "numpy_interop.hpp"
-#include "utility_functions.hpp"
 #include "type_functions.hpp"
-#include "array_functions.hpp"
-#include "array_from_py_typededuction.hpp"
+#include "utility_functions.hpp"
 
-#include <dynd/kernels/assignment_kernels.hpp>
 #include <dynd/func/elwise.hpp>
+#include <dynd/kernels/assignment_kernels.hpp>
 #include <dynd/kernels/tuple_assignment_kernels.hpp>
 #include <dynd/types/struct_type.hpp>
 
@@ -165,6 +165,12 @@ dynd::nd::callable pydynd::nd::copy_from_numpy::make()
   return dynd::nd::functional::elwise(
       dynd::nd::callable::make<copy_from_numpy_kernel>(
           dynd::ndt::type("(void, broadcast: bool) -> T"), 0));
+}
+
+dynd::nd::callable &pydynd::nd::copy_from_numpy::get()
+{
+  static dynd::nd::callable self = pydynd::nd::copy_from_numpy::make();
+  return self;
 }
 
 struct pydynd::nd::copy_from_numpy pydynd::nd::copy_from_numpy;


### PR DESCRIPTION
Update Python bindings to match https://github.com/libdynd/libdynd/pull/990.