### PR TITLE
Add verbatim to improve cross-platform compatibility of Cython CMake interop

### DIFF
--- a/cmake/UseCython.cmake
+++ b/cmake/UseCython.cmake
@@ -155,6 +155,7 @@ function( compile_pyx _name _pyx_target_name _module_name _directories _pyx_file
     #BYPRODUCTS ${_generated_files}
     COMMENT "${_cython_comment}"
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${_directories}
+    VERBATIM
     )
 
   set_target_properties(${_pyx_target_name}


### PR DESCRIPTION
According to https://cmake.org/cmake/help/v3.0/command/add_custom_target.html this helps make sure custom commands are routed properly through the various layers of makefiles in the build system.