### PR TITLE
Pxd extras

### DIFF
--- a/dynd/cpp/array.pxd
+++ b/dynd/cpp/array.pxd
@@ -40,17 +40,25 @@ cdef extern from 'dynd/array.hpp' namespace 'dynd::nd' nogil:
 
         bool is_null()
 
-        array operator<(array &)
-        array operator<=(array &)
-        array operator==(array &)
-        array operator!=(array &)
-        array operator>=(array &)
-        array operator>(array &)
-
         void assign(array &) except +translate_exception
         array eval() except +translate_exception
         array cast(type) except +translate_exception
         array ucast(type, ssize_t) except +translate_exception
+        
+        # These should only be used with versions of Cython later than 0.23.
+        # Otherwise the exception handler isn't properly applied and the
+        # resulting uncaught C++ exceptions can crash the Python interpreter.
+        array operator<(array&) except +translate_exception
+        array operator<=(array&) except +translate_exception
+        array operator==(array&) except +translate_exception
+        array operator!=(array&) except +translate_exception
+        array operator>=(array&) except +translate_exception
+        array operator>(array&) except +translate_exception
+        array operator+(array&) except +translate_exception
+        array operator-(array&) except +translate_exception
+        array operator*(array&) except +translate_exception
+        array operator/(array&) except +translate_exception
+        array operator()(...) except +translate_exception
 
     array empty(type &tp) except +translate_exception
 

--- a/dynd/cpp/irange.pxd
+++ b/dynd/cpp/irange.pxd
@@ -1,0 +1,12 @@
+from ..config cimport translate_exception
+
+cdef extern from "dynd/irange.hpp" namespace "dynd" nogil:
+    cppclass irange:
+        irange()
+        # Use size_t for this interface since Cython doesn't know
+        # how to directly convert integer literals in the source
+        # to intptr_t. It can do that with size_t and on the overwhelming
+        # majority of platforms that's exactly the same thing.
+        irange(size_t)
+        irange(size_t, size_t)
+        irange(size_t, size_t, size_t)


### PR DESCRIPTION
This fills in a few extra pieces necessary to make the C++ `nd::array` class minimally usable from within Cython.