### PR TITLE
Array property may now raise std::invalid_argument().

### DIFF
--- a/dynd/cpp/array.pxd
+++ b/dynd/cpp/array.pxd
@@ -29,7 +29,7 @@ cdef extern from 'dynd/array.hpp' namespace 'dynd::nd' nogil:
         intptr_t get_dim_size() except +translate_exception
         intptr_t get_dim_size(intptr_t) except +translate_exception
 
-        array p(string)
+        array p(string) except +translate_exception
 
         char *data() const
         const char *cdata() const

--- a/dynd/nd/array.pyx
+++ b/dynd/nd/array.pyx
@@ -262,7 +262,10 @@ cdef class array(object):
             if (pair.first == <string> name):
                 return dynd_nd_array_from_cpp(pair.second(self.v))
 
-        return dynd_nd_array_from_cpp(self.v.p(name))
+        try:
+            return dynd_nd_array_from_cpp(self.v.p(name))
+        except ValueError:
+            raise AttributeError(name)
 
     def __setattr__(self, name, value):
         if self.v.is_null():


### PR DESCRIPTION

This is an update for the change in #1013 (libdynd).