### PR TITLE
libdynd strings always have utf-8 encoding.

### DIFF
--- a/dynd/include/type_functions.hpp
+++ b/dynd/include/type_functions.hpp
@@ -139,10 +139,8 @@ inline dynd::ndt::type dynd_make_fixed_string_type(intptr_t size,
   return dynd::ndt::fixed_string_type::make(size, encoding);
 }
 
-inline dynd::ndt::type dynd_make_string_type(PyObject *DYND_UNUSED(encoding_obj))
+inline dynd::ndt::type dynd_make_string_type()
 {
-  // dynd::string_encoding_t encoding = encoding_from_pyobject(encoding_obj);
-
   return dynd::ndt::make_type<dynd::ndt::string_type>();
 }
 

--- a/dynd/ndt/type.pyx
+++ b/dynd/ndt/type.pyx
@@ -65,7 +65,7 @@ cdef extern from 'type_functions.hpp' namespace 'pydynd':
     string _type_repr(_type &)
 
     _type dynd_make_fixed_string_type(int, object) except +translate_exception
-    _type dynd_make_string_type(object) except +translate_exception
+    _type dynd_make_string_type() except +translate_exception
     _type dynd_make_pointer_type(_type&) except +translate_exception
     _type dynd_make_struct_type(object, object) except +translate_exception
     _type dynd_make_cstruct_type(object, object) except +translate_exception
@@ -491,27 +491,18 @@ def make_fixed_string(int size, encoding=None):
     result.v = dynd_make_fixed_string_type(size, encoding)
     return result
 
-def make_string(encoding=None):
+def make_string():
     """
-    ndt.make_string(encoding='utf_8')
-    Constructs a variable-sized string dynd type
-    with the specified encoding.
-    Parameters
-    ----------
-    encoding : string, optional
-        The encoding used for storing unicode code points. Supported
-        values are 'ascii', 'utf_8', 'utf_16', 'utf_32', 'ucs_2'.
-        Default: 'utf_8'.
+    ndt.make_string()
+    Constructs a variable-sized string dynd type with uft-8 encoding.
     Examples
     --------
     >>> from dynd import nd, ndt
     >>> ndt.make_string()
     ndt.string
-    >>> ndt.make_string('utf_16')
-    ndt.type("string['utf16']")
     """
     cdef type result = type()
-    result.v = dynd_make_string_type(encoding)
+    result.v = dynd_make_string_type()
     return result
 
 def make_struct(field_types, field_names):


### PR DESCRIPTION

For the purpose of documenting the current state of libdynd's type system it would be great to remove all ambiguities.  In this case I'm not sure if other encodings apart from utf-8 were planned on the Python level.