### PR TITLE
Cython Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ matrix:
     compiler: gcc
     install:
       # Use the version of numpy that comes preinstalled.
-      - travis_retry pip install --install-option="--no-cython-compile" Cython==0.23
+      - travis_retry pip install --install-option="--no-cython-compile" Cython==0.24
       - python -c "from __future__ import print_function; import numpy; print(numpy.__version__)"
       - mkdir libraries
       - pushd libraries

--- a/BUILD_INSTALL.md
+++ b/BUILD_INSTALL.md
@@ -11,8 +11,8 @@ clang 3.4 and later have been tested.
 2. Get the prerequisites.
   * CMake >= 2.8.11
   * Python 2.7, 3.4, or 3.5
-  * Cython >= 0.23
-  * NumPy >= 1.71
+  * Cython >= 0.24
+  * NumPy >= 1.7.1
   * git (for cloning the github repositories)
   * Nose (Only for generating xunit .xml output when running tests)
 
@@ -63,7 +63,7 @@ In some development environments, such as MSVC or XCode, you may prefer
 to develop libdynd and dynd-python together in one project. This is
 supported by including libdynd in the "libraries/libdynd" subdirectory
 of dynd-python, and running cmake with "-DDYND_INSTALL_LIB=OFF".
-For example, to set this up on Windows with MSVC 2013, do:
+For example, to set this up on Windows with MSVC 2015, do:
 
   ```
   D:\>git clone https://github.com/libdynd/dynd-python

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
 #    - cmake [unix]
     - python
     - setuptools
-    - cython
+    - cython >=0.24
     - numpy
     - libdynd
   run:

--- a/postprocess.py
+++ b/postprocess.py
@@ -1,16 +1,12 @@
 from __future__ import print_function
 
-def postprocess(files):
-    # Remove erroneous #line directives since we aren't including them deliberately
-    # and they cause compilation failures on Windows.
-    for cpp_file in files:
-        print('Postprocessing {}'.format(cpp_file))
-        with open(cpp_file, 'r') as f:
-            lines = f.readlines()
-        lines = [line for line in lines if not line.startswith('#line')]
-        with open(cpp_file, 'w') as f:
-            f.writelines(lines)
+# This file is a placeholder that is run after Cython has generated all the
+# C++ files needed to create the Python bindings but before the C++ compiler
+# builds any of the C++ files into actual binaries. It can be used to
+# postprocess the generated C++ files to work around bugs in Cython
+# when bugfixes already accepted upstream cannot be worked around and are
+# not included in an existing Cython release.
 
 if __name__ == '__main__':
     from sys import argv
-    postprocess(argv[1:])
+    pass


### PR DESCRIPTION
This makes Cython version 0.24 required. That release includes a variety of very relevant bugfixes.