### PR TITLE
Incremental build

### DIFF
--- a/cmake/UseCython.cmake
+++ b/cmake/UseCython.cmake
@@ -142,7 +142,7 @@ function( compile_pyx _name _pyx_target_name _module_name _directories _pyx_file
   set_source_files_properties( ${_generated_files} PROPERTIES GENERATED TRUE )
 
   set(_cython_command ${CYTHON_EXECUTABLE} ${_cxx_arg}
-  ${_annotate_arg} ${_no_docstrings_arg} ${_cython_debug_arg} ${CYTHON_FLAGS}
+  ${_annotate_arg} ${_no_docstrings_arg} ${_cython_debug_arg} ${CYTHON_FLAGS} --timestamps
   --output-file "${CMAKE_CURRENT_BINARY_DIR}/${_directories}/${_module_name}.${_extension}" ${_pyx_location})
   string(REPLACE ";" " " _cython_comment "${_cython_command}")
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, Extension
 
 import os, sys
 from os import chdir, getcwd
-from os.path import abspath, dirname, split
+from os.path import abspath, dirname, split, samefile
 import shlex
 from subprocess import check_output
 
@@ -73,7 +73,7 @@ class cmake_build_ext(build_ext):
         cachedir = re.search('CMAKE_CACHEFILE_DIR:INTERNAL=(.*)', cachefile.read()).group(1)
         cachefile.close()
 
-        if (cachedir != build_temp):
+        if not samefile(cachedir, build_temp):
             return
 
     pyexe_option = '-DPYTHON_EXECUTABLE=%s' % sys.executable


### PR DESCRIPTION
This fixes a few small issues with the incremental build on Windows. When using a version of Cython recent enough to have https://github.com/cython/cython/pull/513 this makes incremental builds work. It's still probably not as fast as it ought to be since CMake is run each time, but this prevents the C++ compiler from getting called unnecessarily.