### PR TITLE
Remove cython-level dependency of type module on array module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,10 @@ matrix:
       - python -c "from __future__ import print_function; import numpy; print(numpy.__version__)"
       - git clone --depth=1 https://github.com/libdynd/libdynd.git
       - python setup.py install
+    script:
+      - pushd ..
+      - python -c "import dynd; dynd.test(verbosity=2, exit=True)"
+      - popd
   - language: objective-c
     os: osx
     compiler: clang
@@ -63,7 +67,7 @@ matrix:
     addons:
     before_install:
 
-install:
+script:
   - wget https://repo.continuum.io/miniconda/Miniconda${Miniconda_ver}-latest-${Miniconda_OS}-x86_64.sh
   - bash Miniconda${Miniconda_ver}-latest-${Miniconda_OS}-x86_64.sh -b
   - export PATH=$HOME/miniconda${Miniconda_ver}/bin:$PATH
@@ -72,11 +76,6 @@ install:
   - conda build conda.recipe --channel dynd/channel/dev
   - conda install --yes numpy libdynd --channel dynd/channel/dev
   - conda install $(conda build --output conda.recipe | grep bz2)
-
-script:
-  - pushd ..
-  - python -c "import dynd; dynd.test(verbosity=2, exit=True)"
-  - popd
 
 after_success:
   - if [ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_PULL_REQUEST == "false" ]; then anaconda --token $ANACONDA_TOKEN upload $(conda build --output conda.recipe) --user dynd --channel dev; fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,14 @@ endforeach(pyx_api_file)
 
 set_source_files_properties(dynd/config.pyx PROPERTIES CYTHON_API 1)
 
+cython_add_module(dynd.config dynd.config_pyx True
+                  dynd/include/exception_translation.hpp
+                  dynd/src/array_conversions.cpp
+                  dynd/src/type_conversions.cpp
+                  dynd/src/type_deduction.cpp
+                  ${CMAKE_CURRENT_BINARY_DIR}/dynd/src/git_version.cpp
+                  )
+
 cython_add_module(dynd.nd.array dynd.nd.array_pyx True
                   # Additional C++ source files:
                   dynd/include/numpy_interop.hpp
@@ -199,20 +207,6 @@ cython_add_module(dynd.nd.array dynd.nd.array_pyx True
                   dynd/src/type_deduction.cpp
                   dynd/src/types/pyobject_type.cpp
                   )
-if (DYND_PYTHON_INPLACE_BUILD)
-    set_target_library_output_dir(dynd.nd.array "${PROJECT_SOURCE_DIR}/dynd/nd")
-endif()
-
-cython_add_module(dynd.config dynd.config_pyx True
-                  dynd/include/exception_translation.hpp
-                  dynd/src/array_conversions.cpp
-                  dynd/src/type_conversions.cpp
-                  dynd/src/type_deduction.cpp
-                  ${CMAKE_CURRENT_BINARY_DIR}/dynd/src/git_version.cpp
-                  )
-if (DYND_PYTHON_INPLACE_BUILD)
-    set_target_library_output_dir(dynd.config "${PROJECT_SOURCE_DIR}/dynd")
-endif()
 
 foreach(module dynd.ndt.type dynd.ndt.json dynd.nd.callable dynd.nd.functional dynd.nd.registry)
     cython_add_module(${module} ${module}_pyx True
@@ -221,11 +215,13 @@ foreach(module dynd.ndt.type dynd.ndt.json dynd.nd.callable dynd.nd.functional d
                       dynd/src/array_conversions.cpp)
 endforeach(module)
 if (DYND_PYTHON_INPLACE_BUILD)
-    set_target_library_output_dir(dynd.ndt.type "${PROJECT_SOURCE_DIR}/dynd/ndt")
-    set_target_library_output_dir(dynd.ndt.json "${PROJECT_SOURCE_DIR}/dynd/ndt")
+    set_target_library_output_dir(dynd.config "${PROJECT_SOURCE_DIR}/dynd")
+    set_target_library_output_dir(dynd.nd.array "${PROJECT_SOURCE_DIR}/dynd/nd")
     set_target_library_output_dir(dynd.nd.callable "${PROJECT_SOURCE_DIR}/dynd/nd")
     set_target_library_output_dir(dynd.nd.functional "${PROJECT_SOURCE_DIR}/dynd/nd")
     set_target_library_output_dir(dynd.nd.registry "${PROJECT_SOURCE_DIR}/dynd/nd")
+    set_target_library_output_dir(dynd.ndt.type "${PROJECT_SOURCE_DIR}/dynd/ndt")
+    set_target_library_output_dir(dynd.ndt.json "${PROJECT_SOURCE_DIR}/dynd/ndt")
 endif()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,7 @@ cython_add_module(dynd.ndt.type dynd.ndt.type_pyx True
                   # Additional C++ source files:
                   dynd/include/numpy_interop_defines.hpp
                   dynd/include/numpy_type_interop.hpp
+                  dynd/src/array_conversions.cpp
                   dynd/src/init.cpp
                   dynd/src/numpy_type_interop.cpp
                   dynd/src/type_conversions.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -208,7 +208,17 @@ cython_add_module(dynd.nd.array dynd.nd.array_pyx True
                   dynd/src/types/pyobject_type.cpp
                   )
 
-foreach(module dynd.ndt.type dynd.ndt.json dynd.nd.callable dynd.nd.functional dynd.nd.registry)
+cython_add_module(dynd.ndt.type dynd.ndt.type_pyx True
+                  # Additional C++ source files:
+                  dynd/include/numpy_interop_defines.hpp
+                  dynd/include/numpy_type_interop.hpp
+                  dynd/src/init.cpp
+                  dynd/src/numpy_type_interop.cpp
+                  dynd/src/type_conversions.cpp
+                  dynd/src/type_deduction.cpp
+                  )
+
+foreach(module dynd.ndt.json dynd.nd.callable dynd.nd.functional dynd.nd.registry)
     cython_add_module(${module} ${module}_pyx True
                       # Additional C++ source files:
                       dynd/src/type_conversions.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,6 +183,8 @@ set_source_files_properties(dynd/config.pyx PROPERTIES CYTHON_API 1)
 cython_add_module(dynd.nd.array dynd.nd.array_pyx True
                   # Additional C++ source files:
                   dynd/include/numpy_interop.hpp
+                  dynd/include/numpy_interop_defines.hpp
+                  dynd/include/numpy_type_interop.hpp
                   dynd/src/array_as_pep3118.cpp
                   dynd/src/array_as_numpy.cpp
                   dynd/src/array_from_py.cpp
@@ -192,6 +194,7 @@ cython_add_module(dynd.nd.array dynd.nd.array_pyx True
                   dynd/src/init.cpp
                   dynd/src/functional.cpp
                   dynd/src/numpy_interop.cpp
+                  dynd/src/numpy_type_interop.cpp
                   dynd/src/type_conversions.cpp
                   dynd/src/type_deduction.cpp
                   dynd/src/types/pyobject_type.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,6 @@ set_source_files_properties(dynd/config.pyx PROPERTIES CYTHON_API 1)
 
 cython_add_module(dynd.nd.array dynd.nd.array_pyx True
                   # Additional C++ source files:
-                  dynd/include/do_import_array.hpp
                   dynd/include/numpy_interop.hpp
                   dynd/src/array_as_pep3118.cpp
                   dynd/src/array_as_numpy.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,6 @@ cython_add_module(dynd.ndt.type dynd.ndt.type_pyx True
                   # Additional C++ source files:
                   dynd/include/numpy_interop_defines.hpp
                   dynd/include/numpy_type_interop.hpp
-                  dynd/src/array_conversions.cpp
                   dynd/src/init.cpp
                   dynd/src/numpy_type_interop.cpp
                   dynd/src/type_conversions.cpp

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,12 +25,6 @@ build_script:
   - conda install conda-build
   - ps: if(-not $env:APPVEYOR_PULL_REQUEST_NUMBER) { conda install anaconda-client }
   - conda build conda.recipe --channel dynd/channel/dev
-  - conda install numpy libdynd --channel dynd/channel/dev
-  - conda install numba
-  - ps: conda install (conda build --output conda.recipe | select -Last 1)
-  - cd ..
-  - python -c "import dynd; import sys; dynd.test(verbosity=2, exit=True)"
-  - cd dynd-python
 
 on_success:
   # Redirect output from stderr to stdout to avoid having the command for uploading

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -11,5 +11,4 @@ elif [ `uname` == Darwin ]; then
 fi
 
 cd ..
-$PYTHON setup.py build_ext --extra-cmake-args=$EXTRA_CMAKE_ARGS || exit 1
-$PYTHON setup.py install || exit 1
+$PYTHON setup.py build_ext --extra-cmake-args=$EXTRA_CMAKE_ARGS install || exit 1

--- a/conda.recipe/build.sh
+++ b/conda.recipe/build.sh
@@ -7,7 +7,7 @@ echo Setting the compiler...
 if [ `uname` == Linux ]; then
   EXTRA_CMAKE_ARGS=-DCMAKE_SHARED_LINKER_FLAGS=-static-libstdc++
 elif [ `uname` == Darwin ]; then
-  EXTRA_CMAKE_ARGS=
+  EXTRA_CMAKE_ARGS=-DCMAKE_OSX_DEPLOYMENT_TARGET=10.9
 fi
 
 cd ..

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -27,6 +27,8 @@ requirements:
 
 # Test separately to avoid unsatisfiable package dependencies bug on Win32.
 test:
+  requires:
+    - numba
   commands:
     - python -c "import dynd; dynd.test(verbosity=2, exit=True)"
 

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -26,9 +26,9 @@ requirements:
     - libdynd
 
 # Test separately to avoid unsatisfiable package dependencies bug on Win32.
-#test:
-#  commands:
-#    - python -c "import dynd; dynd.test(verbosity=2, exit=True)"
+test:
+  commands:
+    - python -c "import dynd; dynd.test(verbosity=2, exit=True)"
 
 about:
   home: http://libdynd.org

--- a/dynd/config.pyx
+++ b/dynd/config.pyx
@@ -8,12 +8,6 @@ cdef extern from 'exception_translation.hpp':
 cdef void translate_exception():
     _translate_exception()
 
-cdef extern from 'do_import_array.hpp':
-    pass
-
-cdef extern from 'numpy_interop.hpp' namespace 'pydynd':
-    void import_numpy()
-
 cdef extern from 'git_version.hpp' namespace 'pydynd':
     extern char[] dynd_python_version_string
     extern char[] dynd_python_git_sha1
@@ -25,9 +19,6 @@ _dynd_version_string = str(<char *>dynd_version_string)
 _dynd_git_sha1 = str(<char *>dynd_git_sha1)
 _dynd_python_version_string = str(<char *>dynd_python_version_string)
 _dynd_python_git_sha1 = str(<char *>dynd_python_git_sha1)
-
-# Initialize Numpy
-import_numpy()
 
 # Exceptions to convert from C++
 class BroadcastError(Exception):

--- a/dynd/include/array_from_py.hpp
+++ b/dynd/include/array_from_py.hpp
@@ -29,11 +29,7 @@ namespace pydynd {
  * \param always_copy If this is set to true, a new copy is always
  *                    created.
  */
-PYDYND_API dynd::nd::array array_from_py(PyObject *obj, uint32_t access_flags,
-                                         bool always_copy);
-
-PYDYND_API dynd::ndt::type xtype_for_prefix(PyObject *obj);
-
+PYDYND_API dynd::nd::array array_from_py(PyObject *obj, uint32_t access_flags, bool always_copy);
 
 void init_array_from_py();
 

--- a/dynd/include/do_import_array.hpp
+++ b/dynd/include/do_import_array.hpp
@@ -1,2 +1,0 @@
-// Trigger the array import (inversion of NO_IMPORT_ARRAY)
-#define NUMPY_IMPORT_ARRAY

--- a/dynd/include/numpy_interop.hpp
+++ b/dynd/include/numpy_interop.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2011-15 DyND Developers
+// Copyright (C) 2011-16 DyND Developers
 // BSD 2-Clause License, see LICENSE.txt
 //
 // This header defines some functions to
@@ -9,16 +9,9 @@
 #ifndef _DYND__NUMPY_INTEROP_HPP_
 #define _DYND__NUMPY_INTEROP_HPP_
 
-#include <sstream>
-#include <string>
-#include <vector>
-
 #include <dynd/array.hpp>
-#include <dynd/type.hpp>
-#include <dynd/types/fixed_string_type.hpp>
-#include <dynd/types/struct_type.hpp>
 
-#include "numpy_interop_defines.hpp"
+#include "numpy_type_interop.hpp"
 #if DYND_NUMPY_INTEROP
 
 #include "type_functions.hpp"
@@ -26,287 +19,6 @@
 #include "visibility.hpp"
 
 namespace pydynd {
-
-/**
- * Converts a numpy type number to a dynd type. This produces an
- * aligned output type.
- *
- * \param numpy_type_num  The numpy type number.
- *
- * \returns  The dynd equivalent of the numpy dtype.
- */
-inline dynd::ndt::type _type_from_numpy_type_num(int numpy_type_num)
-{
-  switch (numpy_type_num) {
-  case NPY_BOOL:
-    return dynd::ndt::make_type<dynd::bool1>();
-  case NPY_BYTE:
-    return dynd::ndt::make_type<npy_byte>();
-  case NPY_UBYTE:
-    return dynd::ndt::make_type<npy_ubyte>();
-  case NPY_SHORT:
-    return dynd::ndt::make_type<npy_short>();
-  case NPY_USHORT:
-    return dynd::ndt::make_type<npy_ushort>();
-  case NPY_INT:
-    return dynd::ndt::make_type<npy_int>();
-  case NPY_UINT:
-    return dynd::ndt::make_type<npy_uint>();
-  case NPY_LONG:
-    return dynd::ndt::make_type<npy_long>();
-  case NPY_ULONG:
-    return dynd::ndt::make_type<npy_ulong>();
-  case NPY_LONGLONG:
-    return dynd::ndt::make_type<npy_longlong>();
-  case NPY_ULONGLONG:
-    return dynd::ndt::make_type<npy_ulonglong>();
-#if NPY_API_VERSION >= 6 // At least NumPy 1.6
-  case NPY_HALF:
-    return dynd::ndt::make_type<dynd::float16>();
-#endif
-  case NPY_FLOAT:
-    return dynd::ndt::make_type<float>();
-  case NPY_DOUBLE:
-    return dynd::ndt::make_type<double>();
-  case NPY_CFLOAT:
-    return dynd::ndt::make_type<dynd::complex<float>>();
-  case NPY_CDOUBLE:
-    return dynd::ndt::make_type<dynd::complex<double>>();
-  default: {
-    std::stringstream ss;
-    ss << "Cannot convert numpy type num " << numpy_type_num << " to a dynd type";
-    throw dynd::type_error(ss.str());
-  }
-  }
-}
-
-/**
- * Given a NumPy struct/record dtype, extracts the field types, names,
- * and offsets.
- *
- * \param d  The struct/record dtype.
- * \param out_field_dtypes  This is filled with borrowed references to the field
- *                          dtypes.
- * \param out_field_names  This is filled with the field names.
- * \param out_field_offsets  This is filled with the field offsets.
- */
-// This doesn't rely on any static initialization from numpy,
-// so it should be fine to inline.
-inline void extract_fields_from_numpy_struct(PyArray_Descr *d, std::vector<PyArray_Descr *> &out_field_dtypes,
-                                             std::vector<std::string> &out_field_names,
-                                             std::vector<size_t> &out_field_offsets)
-{
-  if (!PyDataType_HASFIELDS(d)) {
-    throw dynd::type_error("Tried to treat a non-structured NumPy dtype as a structure");
-  }
-
-  PyObject *names = d->names;
-  Py_ssize_t names_size = PyTuple_GET_SIZE(names);
-
-  for (Py_ssize_t i = 0; i < names_size; ++i) {
-    PyObject *key = PyTuple_GET_ITEM(names, i);
-    PyObject *tup = PyDict_GetItem(d->fields, key);
-    PyArray_Descr *fld_dtype;
-    PyObject *title;
-    int offset = 0;
-    if (!PyArg_ParseTuple(tup, "Oi|O", &fld_dtype, &offset, &title)) {
-      throw dynd::type_error("Numpy struct dtype has corrupt data");
-    }
-    out_field_dtypes.push_back(fld_dtype);
-    out_field_names.push_back(pystring_as_string(key));
-    out_field_offsets.push_back(offset);
-  }
-}
-
-inline dynd::ndt::type _type_from_numpy_dtype(PyArray_Descr *d, size_t data_alignment = 0);
-
-inline dynd::ndt::type make_struct_type_from_numpy_struct(PyArray_Descr *d, size_t data_alignment)
-{
-  std::vector<PyArray_Descr *> field_dtypes;
-  std::vector<std::string> field_names;
-  std::vector<size_t> field_offsets;
-
-  pydynd::extract_fields_from_numpy_struct(d, field_dtypes, field_names, field_offsets);
-
-  std::vector<dynd::ndt::type> field_types;
-
-  if (data_alignment == 0) {
-    data_alignment = (size_t)d->alignment;
-  }
-
-  // The alignment must divide into the total element size,
-  // shrink it until it does.
-  while (!dynd::offset_is_aligned((size_t)d->elsize, data_alignment)) {
-    data_alignment >>= 1;
-  }
-
-  for (size_t i = 0; i < field_dtypes.size(); ++i) {
-    PyArray_Descr *fld_dtype = field_dtypes[i];
-    size_t offset = field_offsets[i];
-    field_types.push_back(pydynd::_type_from_numpy_dtype(fld_dtype, data_alignment));
-    // If the field isn't aligned enough, turn it into an unaligned type
-    if (!dynd::offset_is_aligned(offset | data_alignment, field_types.back().get_data_alignment())) {
-      throw std::runtime_error("field isn't unaligned");
-    }
-  }
-
-  // Make a cstruct if possible, struct otherwise
-  return dynd::ndt::make_type<dynd::ndt::struct_type>(field_names, field_types);
-}
-
-// Forward declare this now. Include type_functions.hpp at the end.
-inline dynd::ndt::type dynd_make_fixed_dim_type(PyObject *shape, const dynd::ndt::type &element_tp);
-
-/**
- * Converts a numpy dtype to a dynd type. Use the data_alignment
- * parameter to get accurate alignment, as Numpy may have misaligned data,
- * or may report a smaller alignment than is necessary based on the data.
- *
- * \param d  The numpy dtype to convert.
- * \param data_alignment  If associated with particular data, the actual
- *                        alignment of that data. The default of zero
- *                        causes it to use Numpy's data alignment.
- *
- * \returns  The dynd equivalent of the numpy dtype.
- */
-inline dynd::ndt::type _type_from_numpy_dtype(PyArray_Descr *d, size_t data_alignment)
-{
-  dynd::ndt::type dt;
-
-  if (PyDataType_HASSUBARRAY(d)) {
-    dt = _type_from_numpy_dtype(d->subarray->base, data_alignment);
-    return dynd_make_fixed_dim_type(d->subarray->shape, dt);
-  }
-
-  switch (d->type_num) {
-  case NPY_BOOL:
-    dt = dynd::ndt::make_type<dynd::bool1>();
-    break;
-  case NPY_BYTE:
-    dt = dynd::ndt::make_type<npy_byte>();
-    break;
-  case NPY_UBYTE:
-    dt = dynd::ndt::make_type<npy_ubyte>();
-    break;
-  case NPY_SHORT:
-    dt = dynd::ndt::make_type<npy_short>();
-    break;
-  case NPY_USHORT:
-    dt = dynd::ndt::make_type<npy_ushort>();
-    break;
-  case NPY_INT:
-    dt = dynd::ndt::make_type<npy_int>();
-    break;
-  case NPY_UINT:
-    dt = dynd::ndt::make_type<npy_uint>();
-    break;
-  case NPY_LONG:
-    dt = dynd::ndt::make_type<npy_long>();
-    break;
-  case NPY_ULONG:
-    dt = dynd::ndt::make_type<npy_ulong>();
-    break;
-  case NPY_LONGLONG:
-    dt = dynd::ndt::make_type<npy_longlong>();
-    break;
-  case NPY_ULONGLONG:
-    dt = dynd::ndt::make_type<npy_ulonglong>();
-    break;
-  case NPY_FLOAT:
-    dt = dynd::ndt::make_type<float>();
-    break;
-  case NPY_DOUBLE:
-    dt = dynd::ndt::make_type<double>();
-    break;
-  case NPY_CFLOAT:
-    dt = dynd::ndt::make_type<dynd::complex<float>>();
-    break;
-  case NPY_CDOUBLE:
-    dt = dynd::ndt::make_type<dynd::complex<double>>();
-    break;
-  case NPY_STRING:
-    dt = dynd::ndt::make_type<dynd::ndt::fixed_string_type>(d->elsize, dynd::string_encoding_ascii);
-    break;
-  case NPY_UNICODE:
-    dt = dynd::ndt::make_type<dynd::ndt::fixed_string_type>(d->elsize / 4, dynd::string_encoding_utf_32);
-    break;
-  case NPY_VOID:
-    dt = make_struct_type_from_numpy_struct(d, data_alignment);
-    break;
-  case NPY_OBJECT: {
-    if (d->fields != NULL && d->fields != Py_None) {
-      // Check for an h5py vlen string type (h5py 2.2 style)
-      PyObject *vlen_tup = PyMapping_GetItemString(d->fields, "vlen");
-      if (vlen_tup != NULL) {
-        pyobject_ownref vlen_tup_owner(vlen_tup);
-        if (PyTuple_Check(vlen_tup) && PyTuple_GET_SIZE(vlen_tup) == 3) {
-          PyObject *type_dict = PyTuple_GET_ITEM(vlen_tup, 2);
-          if (PyDict_Check(type_dict)) {
-            PyObject *type = PyDict_GetItemString(type_dict, "type");
-#if PY_VERSION_HEX < 0x03000000
-            if (type == (PyObject *)&PyString_Type || type == (PyObject *)&PyUnicode_Type) {
-#else
-            if (type == (PyObject *)&PyUnicode_Type) {
-#endif
-              dt = dynd::ndt::make_type<dynd::ndt::string_type>();
-            }
-          }
-        }
-      }
-      else {
-        PyErr_Clear();
-      }
-    }
-    // Check for an h5py vlen string type (h5py 2.3 style)
-    if (d->metadata != NULL && PyDict_Check(d->metadata)) {
-      PyObject *type = PyDict_GetItemString(d->metadata, "vlen");
-#if PY_VERSION_HEX < 0x03000000
-      if (type == (PyObject *)&PyString_Type || type == (PyObject *)&PyUnicode_Type) {
-#else
-      if (type == (PyObject *)&PyUnicode_Type) {
-#endif
-        dt = dynd::ndt::make_type<dynd::ndt::string_type>();
-      }
-    }
-    break;
-  }
-#if NPY_API_VERSION >= 6 // At least NumPy 1.6
-  case NPY_DATETIME: {
-    // Get the dtype info through the CPython API, slower
-    // but lets NumPy's datetime API change without issue.
-    pyobject_ownref mod(PyImport_ImportModule("numpy"));
-    pyobject_ownref dd(PyObject_CallMethod(mod.get(), const_cast<char *>("datetime_data"), const_cast<char *>("O"), d));
-    PyObject *unit = PyTuple_GetItem(dd.get(), 0);
-    if (unit == NULL) {
-      throw std::runtime_error("");
-    }
-    break;
-  }
-#endif // At least NumPy 1.6
-  default:
-    break;
-  }
-
-  if (dt.get_id() == dynd::uninitialized_id) {
-    std::stringstream ss;
-    ss << "unsupported Numpy dtype with type id " << d->type_num;
-    throw dynd::type_error(ss.str());
-  }
-
-  /*
-    if (!PyArray_ISNBO(d->byteorder)) {
-      dt = dynd::ndt::new_adapt_type::make(dt);
-    }
-  */
-
-  // If the data this dtype is for isn't aligned enough,
-  // make an unaligned version.
-  if (data_alignment != 0 && data_alignment < dt.get_data_alignment()) {
-    throw std::runtime_error("unaligned dtype");
-  }
-
-  return dt;
-}
 
 /**
  * When the function _type_from_numpy_dtype returns a type which requires
@@ -320,35 +32,6 @@ inline dynd::ndt::type _type_from_numpy_dtype(PyArray_Descr *d, size_t data_alig
 void fill_arrmeta_from_numpy_dtype(const dynd::ndt::type &tp, PyArray_Descr *d, char *arrmeta);
 
 /**
- * Converts a dynd type to a numpy dtype.
- *
- * \param tp  The dynd type to convert.
- */
-PYDYND_API PyArray_Descr *numpy_dtype_from__type(const dynd::ndt::type &tp);
-
-/**
- * Converts a dynd type to a numpy dtype, also supporting types which
- * rely on their arrmeta for field offset information.
- *
- * \param tp  The dynd type to convert.
- * \param arrmeta  The arrmeta for the dynd type.
- */
-PYDYND_API PyArray_Descr *numpy_dtype_from__type(const dynd::ndt::type &tp, const char *arrmeta);
-
-/**
- * Converts a pytypeobject for a n`umpy scalar
- * into a dynd type.
- *
- * Returns 0 on success, -1 if it didn't match.
- */
-PYDYND_API int _type_from_numpy_scalar_typeobject(PyTypeObject *obj, dynd::ndt::type &out_tp);
-
-/**
- * Gets the dynd type of a numpy scalar object
- */
-dynd::ndt::type _type_of_numpy_scalar(PyObject *obj);
-
-/**
  * Views or copies a numpy PyArrayObject as an nd::array.
  *
  * \param obj  The numpy array object.
@@ -356,8 +39,6 @@ dynd::ndt::type _type_of_numpy_scalar(PyObject *obj);
  * \param always_copy  If true, produce a copy instead of a view.
  */
 dynd::nd::array PYDYND_API array_from_numpy_array(PyArrayObject *obj, uint32_t access_flags, bool always_copy);
-
-dynd::ndt::type PYDYND_API array_from_numpy_array2(PyArrayObject *obj);
 
 // Convenience wrapper for use in Cython where the type has already been
 // checked.
@@ -374,50 +55,6 @@ inline dynd::nd::array array_from_numpy_array_cast(PyObject *obj, uint32_t acces
  * \param access_flags  The requested access flags (0 for default).
  */
 dynd::nd::array array_from_numpy_scalar(PyObject *obj, uint32_t access_flags);
-
-dynd::ndt::type array_from_numpy_scalar2(PyObject *obj);
-
-/**
- * Returns the numpy kind ('i', 'f', etc) of the array.
- */
-inline char numpy_kindchar_of(const dynd::ndt::type &d)
-{
-  switch (d.get_base_id()) {
-  case dynd::bool_kind_id:
-    return 'b';
-  case dynd::int_kind_id:
-    return 'i';
-  case dynd::uint_kind_id:
-    return 'u';
-  case dynd::float_kind_id:
-    return 'f';
-  case dynd::complex_kind_id:
-    return 'c';
-  case dynd::string_kind_id:
-    if (d.get_id() == dynd::fixed_string_id) {
-      const dynd::ndt::base_string_type *esd = d.extended<dynd::ndt::base_string_type>();
-      switch (esd->get_encoding()) {
-      case dynd::string_encoding_ascii:
-        return 'S';
-      case dynd::string_encoding_utf_32:
-        return 'U';
-      default:
-        break;
-      }
-    }
-    break;
-  default:
-    break;
-  }
-
-  std::stringstream ss;
-  ss << "dynd type \"" << d << "\" does not have an equivalent numpy kind";
-  throw dynd::type_error(ss.str());
-}
-
-// Temporary function introduced to avoid dependency on non-standard
-// numpy importing in client modules. Wraps PyArray_DescrCheck.
-PYDYND_API bool is_numpy_dtype(PyObject *o);
 
 } // namespace pydynd
 

--- a/dynd/include/numpy_interop.hpp
+++ b/dynd/include/numpy_interop.hpp
@@ -9,74 +9,23 @@
 #ifndef _DYND__NUMPY_INTEROP_HPP_
 #define _DYND__NUMPY_INTEROP_HPP_
 
-#include <Python.h>
-
+#include <sstream>
 #include <string>
 #include <vector>
-
-#include "type_functions.hpp"
-#include "utility_functions.hpp"
-
-// Define this to 1 or 0 depending on whether numpy interop
-// should be compiled in.
-#define DYND_NUMPY_INTEROP 1
-
-// Only expose the things in this header when numpy interop is enabled
-#if DYND_NUMPY_INTEROP
-
-#include <numpy/numpyconfig.h>
-
-// Don't use the deprecated Numpy functions
-#ifdef NPY_1_7_API_VERSION
-#define NPY_NO_DEPRECATED_API 8 // NPY_1_7_API_VERSION
-#else
-#define NPY_ARRAY_NOTSWAPPED NPY_NOTSWAPPED
-#define NPY_ARRAY_ALIGNED NPY_ALIGNED
-#define NPY_ARRAY_WRITEABLE NPY_WRITEABLE
-#define NPY_ARRAY_UPDATEIFCOPY NPY_UPDATEIFCOPY
-#endif
-
-#define PY_ARRAY_UNIQUE_SYMBOL pydynd_ARRAY_API
-#define PY_UFUNC_UNIQUE_SYMBOL pydynd_UFUNC_API
-// Invert the importing signal to match how numpy wants it
-#ifndef NUMPY_IMPORT_ARRAY
-#define NO_IMPORT_ARRAY
-#define NO_IMPORT_UFUNC
-#endif
-
-#include <sstream>
 
 #include <dynd/array.hpp>
 #include <dynd/type.hpp>
 #include <dynd/types/fixed_string_type.hpp>
 #include <dynd/types/struct_type.hpp>
 
-#include <numpy/ndarrayobject.h>
-#include <numpy/ufuncobject.h>
+#include "numpy_interop_defines.hpp"
+#if DYND_NUMPY_INTEROP
 
+#include "type_functions.hpp"
+#include "utility_functions.hpp"
 #include "visibility.hpp"
 
-#ifndef NPY_DATETIME_NAT
-#define NPY_DATETIME_NAT NPY_MIN_INT64
-#endif
-#ifndef NPY_ARRAY_WRITEABLE
-#define NPY_ARRAY_WRITEABLE NPY_WRITEABLE
-#endif
-#ifndef NPY_ARRAY_ALIGNED
-#define NPY_ARRAY_ALIGNED NPY_ALIGNED
-#endif
-
 namespace pydynd {
-
-inline int import_numpy()
-{
-#ifdef NUMPY_IMPORT_ARRAY
-  import_array1(-1);
-  import_umath1(-1);
-#endif
-
-  return 0;
-}
 
 /**
  * Converts a numpy type number to a dynd type. This produces an
@@ -473,45 +422,5 @@ PYDYND_API bool is_numpy_dtype(PyObject *o);
 } // namespace pydynd
 
 #endif // DYND_NUMPY_INTEROP
-
-// Make a no-op import_numpy for Cython to call,
-// so it doesn't need to know about DYND_NUMPY_INTEROP
-#if !DYND_NUMPY_INTEROP
-namespace pydynd {
-
-inline int import_numpy() { return 0; }
-
-// If we're not building against Numpy, define our
-// own version of this struct to use.
-typedef struct {
-  int two; /* contains the integer 2 as a sanity check */
-
-  int nd; /* number of dimensions */
-
-  char typekind; /* kind in array --- character code of typestr */
-
-  int element_size; /* size of each element */
-
-  int flags; /* how should be data interpreted. Valid
-              * flags are CONTIGUOUS (1), F_CONTIGUOUS (2),
-              * ALIGNED (0x100), NOTSWAPPED (0x200), and
-              * WRITEABLE (0x400).  ARR_HAS_DESCR (0x800)
-              * states that arrdescr field is present in
-              * structure
-              */
-
-  npy_intp *shape; /* A length-nd array of shape information */
-
-  npy_intp *strides; /* A length-nd array of stride information */
-
-  void *data; /* A pointer to the first element of the array */
-
-  PyObject *descr; /* A list of fields or NULL (ignored if flags
-                    * does not have ARR_HAS_DESCR flag set)
-                    */
-} PyArrayInterface;
-
-} // namespace pydynd
-#endif // !DYND_NUMPY_INTEROP
 
 #endif // _DYND__NUMPY_INTEROP_HPP_

--- a/dynd/include/numpy_interop_defines.hpp
+++ b/dynd/include/numpy_interop_defines.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (C) 2011-15 DyND Developers
+// Copyright (C) 2011-16 DyND Developers
 // BSD 2-Clause License, see LICENSE.txt
 //
 // This header defines some functions to

--- a/dynd/include/numpy_interop_defines.hpp
+++ b/dynd/include/numpy_interop_defines.hpp
@@ -1,0 +1,103 @@
+//
+// Copyright (C) 2011-15 DyND Developers
+// BSD 2-Clause License, see LICENSE.txt
+//
+// This header defines some functions to
+// interoperate with numpy
+//
+
+#pragma once
+
+#include <Python.h>
+
+// Define this to 1 or 0 depending on whether numpy interop
+// should be compiled in.
+#define DYND_NUMPY_INTEROP 1
+
+// Only expose the things in this header when numpy interop is enabled
+#if DYND_NUMPY_INTEROP
+
+#include <numpy/numpyconfig.h>
+
+// Don't use the deprecated Numpy functions
+#ifdef NPY_1_7_API_VERSION
+#define NPY_NO_DEPRECATED_API 8 // NPY_1_7_API_VERSION
+#else
+#define NPY_ARRAY_NOTSWAPPED NPY_NOTSWAPPED
+#define NPY_ARRAY_ALIGNED NPY_ALIGNED
+#define NPY_ARRAY_WRITEABLE NPY_WRITEABLE
+#define NPY_ARRAY_UPDATEIFCOPY NPY_UPDATEIFCOPY
+#endif
+
+#define PY_ARRAY_UNIQUE_SYMBOL pydynd_ARRAY_API
+#define PY_UFUNC_UNIQUE_SYMBOL pydynd_UFUNC_API
+// Invert the importing signal to match how numpy wants it
+#ifndef NUMPY_IMPORT_ARRAY
+#define NO_IMPORT_ARRAY
+#define NO_IMPORT_UFUNC
+#endif
+
+#include <numpy/ndarrayobject.h>
+#include <numpy/ufuncobject.h>
+
+#ifndef NPY_DATETIME_NAT
+#define NPY_DATETIME_NAT NPY_MIN_INT64
+#endif
+#ifndef NPY_ARRAY_WRITEABLE
+#define NPY_ARRAY_WRITEABLE NPY_WRITEABLE
+#endif
+#ifndef NPY_ARRAY_ALIGNED
+#define NPY_ARRAY_ALIGNED NPY_ALIGNED
+#endif
+
+inline int import_numpy()
+{
+#ifdef NUMPY_IMPORT_ARRAY
+  import_array1(-1);
+  import_umath1(-1);
+#endif
+
+  return 0;
+}
+
+#endif // DYND_NUMPY_INTEROP
+
+// Make a no-op import_numpy for Cython to call,
+// so it doesn't need to know about DYND_NUMPY_INTEROP
+#if !DYND_NUMPY_INTEROP
+namespace pydynd {
+
+inline int import_numpy() { return 0; }
+
+// If we're not building against Numpy, define our
+// own version of this struct to use.
+typedef struct {
+  int two; /* contains the integer 2 as a sanity check */
+
+  int nd; /* number of dimensions */
+
+  char typekind; /* kind in array --- character code of typestr */
+
+  int element_size; /* size of each element */
+
+  int flags; /* how should be data interpreted. Valid
+              * flags are CONTIGUOUS (1), F_CONTIGUOUS (2),
+              * ALIGNED (0x100), NOTSWAPPED (0x200), and
+              * WRITEABLE (0x400).  ARR_HAS_DESCR (0x800)
+              * states that arrdescr field is present in
+              * structure
+              */
+
+  npy_intp *shape; /* A length-nd array of shape information */
+
+  npy_intp *strides; /* A length-nd array of stride information */
+
+  void *data; /* A pointer to the first element of the array */
+
+  PyObject *descr; /* A list of fields or NULL (ignored if flags
+                    * does not have ARR_HAS_DESCR flag set)
+                    */
+} PyArrayInterface;
+
+} // namespace pydynd
+#endif // !DYND_NUMPY_INTEROP

--- a/dynd/include/numpy_type_interop.hpp
+++ b/dynd/include/numpy_type_interop.hpp
@@ -1,0 +1,386 @@
+//
+// Copyright (C) 2011-16 DyND Developers
+// BSD 2-Clause License, see LICENSE.txt
+//
+// This header defines some functions to
+// interoperate with numpy
+//
+
+#pragma once
+
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include <dynd/type.hpp>
+#include <dynd/types/fixed_string_type.hpp>
+#include <dynd/types/struct_type.hpp>
+
+#include "numpy_interop_defines.hpp"
+#if DYND_NUMPY_INTEROP
+
+#include "type_functions.hpp"
+#include "utility_functions.hpp"
+#include "visibility.hpp"
+
+namespace pydynd {
+
+/**
+ * Converts a numpy type number to a dynd type. This produces an
+ * aligned output type.
+ *
+ * \param numpy_type_num  The numpy type number.
+ *
+ * \returns  The dynd equivalent of the numpy dtype.
+ */
+inline dynd::ndt::type _type_from_numpy_type_num(int numpy_type_num)
+{
+  switch (numpy_type_num) {
+  case NPY_BOOL:
+    return dynd::ndt::make_type<dynd::bool1>();
+  case NPY_BYTE:
+    return dynd::ndt::make_type<npy_byte>();
+  case NPY_UBYTE:
+    return dynd::ndt::make_type<npy_ubyte>();
+  case NPY_SHORT:
+    return dynd::ndt::make_type<npy_short>();
+  case NPY_USHORT:
+    return dynd::ndt::make_type<npy_ushort>();
+  case NPY_INT:
+    return dynd::ndt::make_type<npy_int>();
+  case NPY_UINT:
+    return dynd::ndt::make_type<npy_uint>();
+  case NPY_LONG:
+    return dynd::ndt::make_type<npy_long>();
+  case NPY_ULONG:
+    return dynd::ndt::make_type<npy_ulong>();
+  case NPY_LONGLONG:
+    return dynd::ndt::make_type<npy_longlong>();
+  case NPY_ULONGLONG:
+    return dynd::ndt::make_type<npy_ulonglong>();
+#if NPY_API_VERSION >= 6 // At least NumPy 1.6
+  case NPY_HALF:
+    return dynd::ndt::make_type<dynd::float16>();
+#endif
+  case NPY_FLOAT:
+    return dynd::ndt::make_type<float>();
+  case NPY_DOUBLE:
+    return dynd::ndt::make_type<double>();
+  case NPY_CFLOAT:
+    return dynd::ndt::make_type<dynd::complex<float>>();
+  case NPY_CDOUBLE:
+    return dynd::ndt::make_type<dynd::complex<double>>();
+  default: {
+    std::stringstream ss;
+    ss << "Cannot convert numpy type num " << numpy_type_num << " to a dynd type";
+    throw dynd::type_error(ss.str());
+  }
+  }
+}
+
+/**
+ * Given a NumPy struct/record dtype, extracts the field types, names,
+ * and offsets.
+ *
+ * \param d  The struct/record dtype.
+ * \param out_field_dtypes  This is filled with borrowed references to the field
+ *                          dtypes.
+ * \param out_field_names  This is filled with the field names.
+ * \param out_field_offsets  This is filled with the field offsets.
+ */
+// This doesn't rely on any static initialization from numpy,
+// so it should be fine to inline.
+inline void extract_fields_from_numpy_struct(PyArray_Descr *d, std::vector<PyArray_Descr *> &out_field_dtypes,
+                                             std::vector<std::string> &out_field_names,
+                                             std::vector<size_t> &out_field_offsets)
+{
+  if (!PyDataType_HASFIELDS(d)) {
+    throw dynd::type_error("Tried to treat a non-structured NumPy dtype as a structure");
+  }
+
+  PyObject *names = d->names;
+  Py_ssize_t names_size = PyTuple_GET_SIZE(names);
+
+  for (Py_ssize_t i = 0; i < names_size; ++i) {
+    PyObject *key = PyTuple_GET_ITEM(names, i);
+    PyObject *tup = PyDict_GetItem(d->fields, key);
+    PyArray_Descr *fld_dtype;
+    PyObject *title;
+    int offset = 0;
+    if (!PyArg_ParseTuple(tup, "Oi|O", &fld_dtype, &offset, &title)) {
+      throw dynd::type_error("Numpy struct dtype has corrupt data");
+    }
+    out_field_dtypes.push_back(fld_dtype);
+    out_field_names.push_back(pystring_as_string(key));
+    out_field_offsets.push_back(offset);
+  }
+}
+
+inline dynd::ndt::type _type_from_numpy_dtype(PyArray_Descr *d, size_t data_alignment = 0);
+
+inline dynd::ndt::type make_struct_type_from_numpy_struct(PyArray_Descr *d, size_t data_alignment)
+{
+  std::vector<PyArray_Descr *> field_dtypes;
+  std::vector<std::string> field_names;
+  std::vector<size_t> field_offsets;
+
+  pydynd::extract_fields_from_numpy_struct(d, field_dtypes, field_names, field_offsets);
+
+  std::vector<dynd::ndt::type> field_types;
+
+  if (data_alignment == 0) {
+    data_alignment = (size_t)d->alignment;
+  }
+
+  // The alignment must divide into the total element size,
+  // shrink it until it does.
+  while (!dynd::offset_is_aligned((size_t)d->elsize, data_alignment)) {
+    data_alignment >>= 1;
+  }
+
+  for (size_t i = 0; i < field_dtypes.size(); ++i) {
+    PyArray_Descr *fld_dtype = field_dtypes[i];
+    size_t offset = field_offsets[i];
+    field_types.push_back(pydynd::_type_from_numpy_dtype(fld_dtype, data_alignment));
+    // If the field isn't aligned enough, turn it into an unaligned type
+    if (!dynd::offset_is_aligned(offset | data_alignment, field_types.back().get_data_alignment())) {
+      throw std::runtime_error("field isn't unaligned");
+    }
+  }
+
+  // Make a cstruct if possible, struct otherwise
+  return dynd::ndt::make_type<dynd::ndt::struct_type>(field_names, field_types);
+}
+
+/**
+ * Converts a numpy dtype to a dynd type. Use the data_alignment
+ * parameter to get accurate alignment, as Numpy may have misaligned data,
+ * or may report a smaller alignment than is necessary based on the data.
+ *
+ * \param d  The numpy dtype to convert.
+ * \param data_alignment  If associated with particular data, the actual
+ *                        alignment of that data. The default of zero
+ *                        causes it to use Numpy's data alignment.
+ *
+ * \returns  The dynd equivalent of the numpy dtype.
+ */
+inline dynd::ndt::type _type_from_numpy_dtype(PyArray_Descr *d, size_t data_alignment)
+{
+  dynd::ndt::type dt;
+
+  if (PyDataType_HASSUBARRAY(d)) {
+    dt = _type_from_numpy_dtype(d->subarray->base, data_alignment);
+    return dynd_make_fixed_dim_type(d->subarray->shape, dt);
+  }
+
+  switch (d->type_num) {
+  case NPY_BOOL:
+    dt = dynd::ndt::make_type<dynd::bool1>();
+    break;
+  case NPY_BYTE:
+    dt = dynd::ndt::make_type<npy_byte>();
+    break;
+  case NPY_UBYTE:
+    dt = dynd::ndt::make_type<npy_ubyte>();
+    break;
+  case NPY_SHORT:
+    dt = dynd::ndt::make_type<npy_short>();
+    break;
+  case NPY_USHORT:
+    dt = dynd::ndt::make_type<npy_ushort>();
+    break;
+  case NPY_INT:
+    dt = dynd::ndt::make_type<npy_int>();
+    break;
+  case NPY_UINT:
+    dt = dynd::ndt::make_type<npy_uint>();
+    break;
+  case NPY_LONG:
+    dt = dynd::ndt::make_type<npy_long>();
+    break;
+  case NPY_ULONG:
+    dt = dynd::ndt::make_type<npy_ulong>();
+    break;
+  case NPY_LONGLONG:
+    dt = dynd::ndt::make_type<npy_longlong>();
+    break;
+  case NPY_ULONGLONG:
+    dt = dynd::ndt::make_type<npy_ulonglong>();
+    break;
+  case NPY_FLOAT:
+    dt = dynd::ndt::make_type<float>();
+    break;
+  case NPY_DOUBLE:
+    dt = dynd::ndt::make_type<double>();
+    break;
+  case NPY_CFLOAT:
+    dt = dynd::ndt::make_type<dynd::complex<float>>();
+    break;
+  case NPY_CDOUBLE:
+    dt = dynd::ndt::make_type<dynd::complex<double>>();
+    break;
+  case NPY_STRING:
+    dt = dynd::ndt::make_type<dynd::ndt::fixed_string_type>(d->elsize, dynd::string_encoding_ascii);
+    break;
+  case NPY_UNICODE:
+    dt = dynd::ndt::make_type<dynd::ndt::fixed_string_type>(d->elsize / 4, dynd::string_encoding_utf_32);
+    break;
+  case NPY_VOID:
+    dt = make_struct_type_from_numpy_struct(d, data_alignment);
+    break;
+  case NPY_OBJECT: {
+    if (d->fields != NULL && d->fields != Py_None) {
+      // Check for an h5py vlen string type (h5py 2.2 style)
+      PyObject *vlen_tup = PyMapping_GetItemString(d->fields, "vlen");
+      if (vlen_tup != NULL) {
+        pyobject_ownref vlen_tup_owner(vlen_tup);
+        if (PyTuple_Check(vlen_tup) && PyTuple_GET_SIZE(vlen_tup) == 3) {
+          PyObject *type_dict = PyTuple_GET_ITEM(vlen_tup, 2);
+          if (PyDict_Check(type_dict)) {
+            PyObject *type = PyDict_GetItemString(type_dict, "type");
+#if PY_VERSION_HEX < 0x03000000
+            if (type == (PyObject *)&PyString_Type || type == (PyObject *)&PyUnicode_Type) {
+#else
+            if (type == (PyObject *)&PyUnicode_Type) {
+#endif
+              dt = dynd::ndt::make_type<dynd::ndt::string_type>();
+            }
+          }
+        }
+      }
+      else {
+        PyErr_Clear();
+      }
+    }
+    // Check for an h5py vlen string type (h5py 2.3 style)
+    if (d->metadata != NULL && PyDict_Check(d->metadata)) {
+      PyObject *type = PyDict_GetItemString(d->metadata, "vlen");
+#if PY_VERSION_HEX < 0x03000000
+      if (type == (PyObject *)&PyString_Type || type == (PyObject *)&PyUnicode_Type) {
+#else
+      if (type == (PyObject *)&PyUnicode_Type) {
+#endif
+        dt = dynd::ndt::make_type<dynd::ndt::string_type>();
+      }
+    }
+    break;
+  }
+#if NPY_API_VERSION >= 6 // At least NumPy 1.6
+  case NPY_DATETIME: {
+    // Get the dtype info through the CPython API, slower
+    // but lets NumPy's datetime API change without issue.
+    pyobject_ownref mod(PyImport_ImportModule("numpy"));
+    pyobject_ownref dd(PyObject_CallMethod(mod.get(), const_cast<char *>("datetime_data"), const_cast<char *>("O"), d));
+    PyObject *unit = PyTuple_GetItem(dd.get(), 0);
+    if (unit == NULL) {
+      throw std::runtime_error("");
+    }
+    break;
+  }
+#endif // At least NumPy 1.6
+  default:
+    break;
+  }
+
+  if (dt.get_id() == dynd::uninitialized_id) {
+    std::stringstream ss;
+    ss << "unsupported Numpy dtype with type id " << d->type_num;
+    throw dynd::type_error(ss.str());
+  }
+
+  /*
+    if (!PyArray_ISNBO(d->byteorder)) {
+      dt = dynd::ndt::new_adapt_type::make(dt);
+    }
+  */
+
+  // If the data this dtype is for isn't aligned enough,
+  // make an unaligned version.
+  if (data_alignment != 0 && data_alignment < dt.get_data_alignment()) {
+    throw std::runtime_error("unaligned dtype");
+  }
+
+  return dt;
+}
+
+/**
+ * Converts a dynd type to a numpy dtype.
+ *
+ * \param tp  The dynd type to convert.
+ */
+PYDYND_API PyArray_Descr *numpy_dtype_from__type(const dynd::ndt::type &tp);
+
+/**
+ * Converts a dynd type to a numpy dtype, also supporting types which
+ * rely on their arrmeta for field offset information.
+ *
+ * \param tp  The dynd type to convert.
+ * \param arrmeta  The arrmeta for the dynd type.
+ */
+PYDYND_API PyArray_Descr *numpy_dtype_from__type(const dynd::ndt::type &tp, const char *arrmeta);
+
+/**
+ * Converts a pytypeobject for a n`umpy scalar
+ * into a dynd type.
+ *
+ * Returns 0 on success, -1 if it didn't match.
+ */
+PYDYND_API int _type_from_numpy_scalar_typeobject(PyTypeObject *obj, dynd::ndt::type &out_tp);
+
+/**
+ * Gets the dynd type of a numpy scalar object
+ */
+dynd::ndt::type _type_of_numpy_scalar(PyObject *obj);
+
+// What are these and how soon can we get rid of them?
+// The names imply they operate on arrays, but the code only involves types.
+dynd::ndt::type PYDYND_API array_from_numpy_array2(PyArrayObject *obj);
+dynd::ndt::type array_from_numpy_scalar2(PyObject *obj);
+
+/**
+ * Returns the numpy kind ('i', 'f', etc) of the array.
+ */
+inline char numpy_kindchar_of(const dynd::ndt::type &d)
+{
+  switch (d.get_base_id()) {
+  case dynd::bool_kind_id:
+    return 'b';
+  case dynd::int_kind_id:
+    return 'i';
+  case dynd::uint_kind_id:
+    return 'u';
+  case dynd::float_kind_id:
+    return 'f';
+  case dynd::complex_kind_id:
+    return 'c';
+  case dynd::string_kind_id:
+    if (d.get_id() == dynd::fixed_string_id) {
+      const dynd::ndt::base_string_type *esd = d.extended<dynd::ndt::base_string_type>();
+      switch (esd->get_encoding()) {
+      case dynd::string_encoding_ascii:
+        return 'S';
+      case dynd::string_encoding_utf_32:
+        return 'U';
+      default:
+        break;
+      }
+    }
+    break;
+  default:
+    break;
+  }
+
+  std::stringstream ss;
+  ss << "dynd type \"" << d << "\" does not have an equivalent numpy kind";
+  throw dynd::type_error(ss.str());
+}
+
+// Temporary function introduced to avoid dependency on non-standard
+// numpy importing in client modules. Wraps PyArray_DescrCheck.
+PYDYND_API bool is_numpy_dtype(PyObject *o);
+
+} // namespace pydynd
+
+#include "type_functions.hpp"
+
+#endif

--- a/dynd/include/type_deduction.hpp
+++ b/dynd/include/type_deduction.hpp
@@ -157,6 +157,8 @@ bool broadcast_as_scalar(const dynd::ndt::type &tp, PyObject *obj);
 
 void init_array_from_py_typededuction();
 
+void register_nd_array_type_deduction(PyTypeObject *, dynd::ndt::type (*)(PyObject *));
+
 PYDYND_API dynd::ndt::type xtype_for_prefix(PyObject *obj);
 
 } // namespace pydynd

--- a/dynd/include/type_deduction.hpp
+++ b/dynd/include/type_deduction.hpp
@@ -44,9 +44,7 @@ enum shape_deduction_t {
  * \param current_axis  The index of the axis within the shape corresponding
  *                      to the object.
  */
-inline void deduce_pylist_shape_and_dtype(PyObject *obj,
-                                          std::vector<intptr_t> &shape,
-                                          dynd::ndt::type &tp,
+inline void deduce_pylist_shape_and_dtype(PyObject *obj, std::vector<intptr_t> &shape, dynd::ndt::type &tp,
                                           size_t current_axis)
 {
   if (PyList_Check(obj)) {
@@ -56,9 +54,8 @@ inline void deduce_pylist_shape_and_dtype(PyObject *obj,
         shape.push_back(size);
       }
       else {
-        throw std::runtime_error(
-            "dynd array doesn't support dimensions "
-            "which are sometimes scalars and sometimes arrays");
+        throw std::runtime_error("dynd array doesn't support dimensions "
+                                 "which are sometimes scalars and sometimes arrays");
       }
     }
     else {
@@ -69,8 +66,7 @@ inline void deduce_pylist_shape_and_dtype(PyObject *obj,
     }
 
     for (Py_ssize_t i = 0; i < size; ++i) {
-      deduce_pylist_shape_and_dtype(PyList_GET_ITEM(obj, i), shape, tp,
-                                    current_axis + 1);
+      deduce_pylist_shape_and_dtype(PyList_GET_ITEM(obj, i), shape, tp, current_axis + 1);
       // Propagate uninitialized_id as a signal an
       // undeducable object was encountered
       if (tp.get_id() == dynd::uninitialized_id) {
@@ -137,8 +133,7 @@ void deduce_pyseq_shape(PyObject *obj, size_t ndim, intptr_t *shape);
  * \param current_axis  The index of the axis within the shape corresponding
  *                      to the object.
  */
-void deduce_pyseq_shape_using_dtype(PyObject *obj, const dynd::ndt::type &tp,
-                                    std::vector<intptr_t> &shape,
+void deduce_pyseq_shape_using_dtype(PyObject *obj, const dynd::ndt::type &tp, std::vector<intptr_t> &shape,
                                     bool initial_pass, size_t current_axis);
 
 /**
@@ -151,9 +146,7 @@ void deduce_pyseq_shape_using_dtype(PyObject *obj, const dynd::ndt::type &tp,
  *    "3 * {x: {a: int32}, y: int32}" -> 2
  *    "3 * {x: {a: int32}, y: {a: int32, b: int32}}" -> 3
  */
-size_t
-get_nonragged_dim_count(const dynd::ndt::type &tp,
-                        size_t max_count = std::numeric_limits<size_t>::max());
+size_t get_nonragged_dim_count(const dynd::ndt::type &tp, size_t max_count = std::numeric_limits<size_t>::max());
 
 /**
  * Analyzes the Python object against the dynd type to heuristically
@@ -163,5 +156,7 @@ get_nonragged_dim_count(const dynd::ndt::type &tp,
 bool broadcast_as_scalar(const dynd::ndt::type &tp, PyObject *obj);
 
 void init_array_from_py_typededuction();
+
+PYDYND_API dynd::ndt::type xtype_for_prefix(PyObject *obj);
 
 } // namespace pydynd

--- a/dynd/nd/array.pxd
+++ b/dynd/nd/array.pxd
@@ -17,4 +17,3 @@ cdef api array dynd_nd_array_from_cpp(_array)
 
 cdef _callable _functional_apply(_type t, object o) except *
 cdef void _registry_assign_init() except *
-cdef _type _xtype_for_prefix(object o) except *

--- a/dynd/nd/array.pxd
+++ b/dynd/nd/array.pxd
@@ -11,8 +11,8 @@ cdef api class array(object)[object dynd_nd_array_pywrapper,
 cdef _array as_cpp_array(object obj) except *
 cpdef array asarray(object obj)
 
-cdef api _array dynd_nd_array_to_cpp(array) except *
-cdef api _array *dynd_nd_array_to_ptr(array) except *
+cdef api _array dynd_nd_array_to_cpp(array) nogil except *
+cdef api _array *dynd_nd_array_to_ptr(array) nogil except *
 cdef api array dynd_nd_array_from_cpp(_array)
 
 cdef _callable _functional_apply(_type t, object o) except *

--- a/dynd/nd/array.pxd
+++ b/dynd/nd/array.pxd
@@ -17,6 +17,4 @@ cdef api array dynd_nd_array_from_cpp(_array)
 
 cdef _callable _functional_apply(_type t, object o) except *
 cdef void _registry_assign_init() except *
-cdef object _numpy_dtype_from__type(const _type &tp)
-cdef bint _is_numpy_dtype(PyObject *o) except *
 cdef _type _xtype_for_prefix(object o) except *

--- a/dynd/nd/array.pyx
+++ b/dynd/nd/array.pyx
@@ -81,7 +81,7 @@ ctypedef cpp_complex[double] cpp_complex_double
 # in scope due to argument naming.
 _builtin_type = type
 
-# Initialize ctypes C level interop data
+# Initialize C level static interop data
 numpy_interop_init()
 init_array_from_py()
 
@@ -1134,21 +1134,6 @@ cdef extern from 'assign.hpp':
 
 cdef void _registry_assign_init() except *:
     assign_init()
-
-cdef extern from "numpy_interop.hpp":
-    ctypedef struct PyArray_Descr
-
-cdef extern from "numpy_interop.hpp" namespace "pydynd":
-    PyArray_Descr *numpy_dtype_from__type(const _type &tp) except +translate_exception
-    # Technically returns a bool.
-    # Rely on an implicit cast to convert it to a bint for Cython.
-    bint is_numpy_dtype(PyObject*)
-
-cdef object _numpy_dtype_from__type(const _type &tp):
-    return <object> numpy_dtype_from__type(tp)
-
-cdef bint _is_numpy_dtype(PyObject *o) except *:
-    return is_numpy_dtype(o)
 
 cdef extern from "array_from_py.hpp" namespace 'pydynd':
     _type xtype_for_prefix(object) except +translate_exception

--- a/dynd/nd/array.pyx
+++ b/dynd/nd/array.pyx
@@ -1134,9 +1134,3 @@ cdef extern from 'assign.hpp':
 
 cdef void _registry_assign_init() except *:
     assign_init()
-
-cdef extern from "array_from_py.hpp" namespace 'pydynd':
-    _type xtype_for_prefix(object) except +translate_exception
-
-cdef _type _xtype_for_prefix(object o) except *:
-    return xtype_for_prefix(o)

--- a/dynd/nd/array.pyx
+++ b/dynd/nd/array.pyx
@@ -3,7 +3,7 @@
 _builtin_type = type
 
 from cpython.object cimport (Py_LT, Py_LE, Py_EQ, Py_NE, Py_GE, Py_GT,
-                             PyObject_TypeCheck)
+                             PyObject_TypeCheck, PyTypeObject)
 from cpython.buffer cimport PyObject_CheckBuffer
 from libcpp.string cimport string
 from libcpp.map cimport map
@@ -25,8 +25,8 @@ from ..cpp.view cimport view as _view
 from ..pyobject_type cimport pyobject_id
 
 from ..config cimport translate_exception
-from ..ndt.type cimport type as _py_type, dynd_ndt_type_to_cpp, as_cpp_type
-from ..ndt.type cimport cpp_type_for
+from ..ndt.type cimport (type as _py_type, dynd_ndt_type_to_cpp, as_cpp_type,
+                         cpp_type_for, _register_nd_array_type_deduction)
 
 cdef extern from 'array_functions.hpp' namespace 'pydynd':
     void array_init_from_pyobject(_array&, object, object, bint, object) except +translate_exception
@@ -586,6 +586,11 @@ cdef array dynd_nd_array_from_cpp(_array a):
     cdef array arr = array.__new__(array)
     arr.v = a
     return arr
+
+cdef _type _type_from_pyarr_wrapper(PyObject *a):
+    return dynd_nd_array_to_cpp(<array>a).get_type()
+
+_register_nd_array_type_deduction(<PyTypeObject*>array, &_type_from_pyarr_wrapper)
 
 cdef _array as_cpp_array(object obj) except *:
     """

--- a/dynd/nd/callable.pxd
+++ b/dynd/nd/callable.pxd
@@ -4,8 +4,8 @@ cdef api class callable(object)[object dynd_nd_callable_pywrapper,
                                 type dynd_nd_callable_pywrapper_type]:
     cdef _callable v
 
-cdef api _callable dynd_nd_callable_to_cpp(callable) except *
+cdef api _callable dynd_nd_callable_to_cpp(callable) nogil except *
 # Provide an API for returning as a pointer since Cython can't handle
 # returning references yet.
-cdef api _callable *dynd_nd_callable_to_ptr(callable) except *
+cdef api _callable *dynd_nd_callable_to_ptr(callable) nogil except *
 cdef api callable wrap(const _callable &)

--- a/dynd/nd/callable.pyx
+++ b/dynd/nd/callable.pyx
@@ -97,21 +97,23 @@ cdef class callable(object):
 
         return ss.str()
 
-cdef _callable dynd_nd_callable_to_cpp(callable c) except *:
+cdef _callable dynd_nd_callable_to_cpp(callable c) nogil except *:
     # Once this becomes a method of the type wrapper class, this check and
     # its corresponding exception handler declaration are no longer necessary
     # since the self parameter is guaranteed to never be None.
-    if c is None:
+    if c is not None:
+        return c.v
+    with gil:
         raise TypeError("Cannot extract DyND C++ callable from None.")
-    return c.v
 
-cdef _callable *dynd_nd_callable_to_ptr(callable c) except *:
+cdef _callable *dynd_nd_callable_to_ptr(callable c) nogil except *:
     # Once this becomes a method of the type wrapper class, this check and
     # its corresponding exception handler declaration are no longer necessary
     # since the self parameter is guaranteed to never be None.
-    if c is None:
+    if c is not None:
+        return &(c.v)
+    with gil:
         raise TypeError("Cannot extract DyND C++ callable from None.")
-    return &(c.v)
 
 # returns a Python object, so no exception specifier is needed.
 cdef callable wrap(const _callable &c):

--- a/dynd/ndt/type.pxd
+++ b/dynd/ndt/type.pxd
@@ -5,8 +5,8 @@ cdef api class type(object)[object dynd_ndt_type_pywrapper,
                             type dynd_ndt_type_pywrapper_type]:
     cdef _type v
 
-cdef api _type dynd_ndt_type_to_cpp(type) except *
-cdef api _type *dynd_ndt_type_to_ptr(type) except *
+cdef api _type dynd_ndt_type_to_cpp(type) nogil except *
+cdef api _type *dynd_ndt_type_to_ptr(type) nogil except *
 cdef api type wrap(const _type&)
 cdef api _type as_cpp_type(object o) except *
 cpdef type astype(object o)

--- a/dynd/ndt/type.pxd
+++ b/dynd/ndt/type.pxd
@@ -1,4 +1,5 @@
 from ..cpp.type cimport type as _type
+from cpython.object cimport PyObject, PyTypeObject
 
 cdef api class type(object)[object dynd_ndt_type_pywrapper,
                             type dynd_ndt_type_pywrapper_type]:
@@ -13,3 +14,5 @@ cpdef type astype(object o)
 cdef object as_numba_type(_type)
 cdef _type from_numba_type(object)
 cdef api _type cpp_type_for(object) except *
+
+cdef void _register_nd_array_type_deduction(PyTypeObject *array_type, _type (*get_type)(PyObject *))

--- a/dynd/ndt/type.pyx
+++ b/dynd/ndt/type.pyx
@@ -84,6 +84,9 @@ cdef extern from "numpy_type_interop.hpp" namespace "pydynd":
     # Rely on an implicit cast to convert it to a bint for Cython.
     bint is_numpy_dtype(PyObject*)
 
+cdef extern from "type_deduction.hpp" namespace 'pydynd':
+    _type xtype_for_prefix(object) except +translate_exception
+
 cdef extern from 'init.hpp' namespace 'pydynd':
     void numpy_interop_init() except *
 
@@ -715,7 +718,7 @@ cdef _type from_numba_type(tp):
     return _type(<type_id_t> _from_numba_type[tp])
 
 cdef _type cpp_type_for(object obj) except *:
-    cdef _type tp = _xtype_for_prefix(obj)
+    cdef _type tp = xtype_for_prefix(obj)
     if (not tp.is_null() and not isinstance(obj, _np.integer)):
         return tp
     if _builtin_type(obj) is builtin_tuple:
@@ -727,6 +730,3 @@ cdef _type cpp_type_for(object obj) except *:
 
 def type_for(obj):
     return wrap(cpp_type_for(obj))
-
-# Avoid circular import issues by importing these last.
-from ..nd.array cimport _xtype_for_prefix

--- a/dynd/ndt/type.pyx
+++ b/dynd/ndt/type.pyx
@@ -310,21 +310,23 @@ cdef class type(object):
         """
         return self.v.match(type(rhs).v)
 
-cdef _type dynd_ndt_type_to_cpp(type t) except *:
+cdef _type dynd_ndt_type_to_cpp(type t) nogil except *:
     # Once this becomes a method of the type wrapper class, this check and
     # its corresponding exception handler declaration are no longer necessary
     # since the self parameter is guaranteed to never be None.
-    if t is None:
+    if t is not None:
+        return t.v
+    with gil:
         raise TypeError("Cannot extract DyND C++ type from None.")
-    return t.v
 
-cdef _type *dynd_ndt_type_to_ptr(type t) except *:
+cdef _type *dynd_ndt_type_to_ptr(type t) nogil except *:
     # Once this becomes a method of the type wrapper class, this check and
     # its corresponding exception handler declaration are no longer necessary
     # since the self parameter is guaranteed to never be None.
-    if t is None:
+    if t is not None:
+        return &(t.v)
+    with gil:
         raise TypeError("Cannot extract DyND C++ type from None.")
-    return &(t.v)
 
 # returns a Python object, so no exception specifier is needed.
 cdef type wrap(const _type &t):

--- a/dynd/ndt/type.pyx
+++ b/dynd/ndt/type.pyx
@@ -1,6 +1,6 @@
 # cython: c_string_type=str, c_string_encoding=ascii
 
-from cpython.object cimport Py_EQ, Py_NE, PyObject
+from cpython.object cimport Py_EQ, Py_NE, PyObject, PyTypeObject
 from libc.stdint cimport (intptr_t, int8_t, int16_t, int32_t, int64_t,
                           uint8_t, uint16_t, uint32_t, uint64_t)
 from libcpp.map cimport map
@@ -85,6 +85,7 @@ cdef extern from "numpy_type_interop.hpp" namespace "pydynd":
     bint is_numpy_dtype(PyObject*)
 
 cdef extern from "type_deduction.hpp" namespace 'pydynd':
+    void register_nd_array_type_deduction(PyTypeObject *array_type, _type (*get_type)(PyObject *))
     _type xtype_for_prefix(object) except +translate_exception
 
 cdef extern from 'init.hpp' namespace 'pydynd':
@@ -126,6 +127,9 @@ type_ids['CALLABLE'] = callable_id
 
 cdef object _numpy_dtype_from__type(const _type &tp):
     return <object> numpy_dtype_from__type(tp)
+
+cdef void _register_nd_array_type_deduction(PyTypeObject *array_type, _type (*get_type)(PyObject *)):
+    register_nd_array_type_deduction(array_type, get_type)
 
 cdef class type(object):
     """

--- a/dynd/src/array_from_py.cpp
+++ b/dynd/src/array_from_py.cpp
@@ -10,6 +10,7 @@
 #include <dynd/exceptions.hpp>
 #include <dynd/memblock/external_memory_block.hpp>
 #include <dynd/memblock/pod_memory_block.hpp>
+#include <dynd/option.hpp>
 #include <dynd/type_promotion.hpp>
 #include <dynd/types/bytes_type.hpp>
 #include <dynd/types/option_type.hpp>
@@ -18,14 +19,13 @@
 #include <dynd/types/substitute_shape.hpp>
 #include <dynd/types/type_type.hpp>
 #include <dynd/types/var_dim_type.hpp>
-#include <dynd/option.hpp>
 
+#include "array_conversions.hpp"
 #include "array_from_py.hpp"
 #include "array_functions.hpp"
-#include "array_conversions.hpp"
 #include "numpy_interop.hpp"
-#include "type_functions.hpp"
 #include "type_deduction.hpp"
+#include "type_functions.hpp"
 #include "types/pyobject_type.hpp"
 #include "utility_functions.hpp"
 
@@ -39,18 +39,14 @@ void pydynd::init_array_from_py()
   PyDateTime_IMPORT;
 }
 
-typedef void (*convert_one_pyscalar_function_t)(const ndt::type &tp,
-                                                const char *arrmeta, char *out,
-                                                PyObject *obj);
+typedef void (*convert_one_pyscalar_function_t)(const ndt::type &tp, const char *arrmeta, char *out, PyObject *obj);
 
-inline void convert_one_pyscalar_bool(const ndt::type &tp, const char *arrmeta,
-                                      char *out, PyObject *obj)
+inline void convert_one_pyscalar_bool(const ndt::type &tp, const char *arrmeta, char *out, PyObject *obj)
 {
   *out = (PyObject_IsTrue(obj) != 0);
 }
 
-inline void convert_one_pyscalar_int32(const ndt::type &tp, const char *arrmeta,
-                                       char *out, PyObject *obj)
+inline void convert_one_pyscalar_int32(const ndt::type &tp, const char *arrmeta, char *out, PyObject *obj)
 {
 #if PY_VERSION_HEX >= 0x03000000
   int32_t value = static_cast<int32_t>(PyLong_AsLong(obj));
@@ -63,8 +59,7 @@ inline void convert_one_pyscalar_int32(const ndt::type &tp, const char *arrmeta,
   *reinterpret_cast<int32_t *>(out) = value;
 }
 
-inline void convert_one_pyscalar_int64(const ndt::type &tp, const char *arrmeta,
-                                       char *out, PyObject *obj)
+inline void convert_one_pyscalar_int64(const ndt::type &tp, const char *arrmeta, char *out, PyObject *obj)
 {
   int64_t value = PyLong_AsLongLong(obj);
   if (value == -1 && PyErr_Occurred()) {
@@ -73,9 +68,7 @@ inline void convert_one_pyscalar_int64(const ndt::type &tp, const char *arrmeta,
   *reinterpret_cast<int64_t *>(out) = value;
 }
 
-inline void convert_one_pyscalar_float32(const ndt::type &tp,
-                                         const char *arrmeta, char *out,
-                                         PyObject *obj)
+inline void convert_one_pyscalar_float32(const ndt::type &tp, const char *arrmeta, char *out, PyObject *obj)
 {
   double value = PyFloat_AsDouble(obj);
   if (value == -1 && PyErr_Occurred()) {
@@ -84,9 +77,7 @@ inline void convert_one_pyscalar_float32(const ndt::type &tp,
   *reinterpret_cast<float *>(out) = static_cast<float>(value);
 }
 
-inline void convert_one_pyscalar_float64(const ndt::type &tp,
-                                         const char *arrmeta, char *out,
-                                         PyObject *obj)
+inline void convert_one_pyscalar_float64(const ndt::type &tp, const char *arrmeta, char *out, PyObject *obj)
 {
   double value = PyFloat_AsDouble(obj);
   if (value == -1 && PyErr_Occurred()) {
@@ -95,21 +86,17 @@ inline void convert_one_pyscalar_float64(const ndt::type &tp,
   *reinterpret_cast<double *>(out) = value;
 }
 
-inline void convert_one_pyscalar_cdouble(const ndt::type &tp,
-                                         const char *arrmeta, char *out,
-                                         PyObject *obj)
+inline void convert_one_pyscalar_cdouble(const ndt::type &tp, const char *arrmeta, char *out, PyObject *obj)
 {
   double value_real = PyComplex_RealAsDouble(obj);
   double value_imag = PyComplex_ImagAsDouble(obj);
   if ((value_real == -1 || value_imag == -1) && PyErr_Occurred()) {
     throw std::exception();
   }
-  *reinterpret_cast<dynd::complex<double> *>(out) =
-      dynd::complex<double>(value_real, value_imag);
+  *reinterpret_cast<dynd::complex<double> *>(out) = dynd::complex<double>(value_real, value_imag);
 }
 
-inline void convert_one_pyscalar_bytes(const ndt::type &tp, const char *arrmeta,
-                                       char *out, PyObject *obj)
+inline void convert_one_pyscalar_bytes(const ndt::type &tp, const char *arrmeta, char *out, PyObject *obj)
 {
   dynd::bytes *out_asp = reinterpret_cast<dynd::bytes *>(out);
   char *data = NULL;
@@ -132,9 +119,7 @@ inline void convert_one_pyscalar_bytes(const ndt::type &tp, const char *arrmeta,
   }
 }
 
-inline void convert_one_pyscalar_ustring(const ndt::type &tp,
-                                         const char *arrmeta, char *out,
-                                         PyObject *obj)
+inline void convert_one_pyscalar_ustring(const ndt::type &tp, const char *arrmeta, char *out, PyObject *obj)
 {
   dynd::string *out_usp = reinterpret_cast<dynd::string *>(out);
   if (PyUnicode_Check(obj)) {
@@ -159,8 +144,7 @@ inline void convert_one_pyscalar_ustring(const ndt::type &tp,
     for (Py_ssize_t i = 0; i < len; ++i) {
       // Only let valid ascii get through
       if ((unsigned char)data[i] >= 128) {
-        throw string_decode_error(data + i, data + i + 1,
-                                  string_encoding_ascii);
+        throw string_decode_error(data + i, data + i + 1, string_encoding_ascii);
       }
       out_usp->begin()[i] = data[i];
     }
@@ -171,17 +155,14 @@ inline void convert_one_pyscalar_ustring(const ndt::type &tp,
   }
 }
 
-inline void convert_one_pyscalar__type(const ndt::type &DYND_UNUSED(tp),
-                                       const char *DYND_UNUSED(arrmeta),
-                                       char *out, PyObject *obj)
+inline void convert_one_pyscalar__type(const ndt::type &DYND_UNUSED(tp), const char *DYND_UNUSED(arrmeta), char *out,
+                                       PyObject *obj)
 {
   ndt::type obj_as_tp = dynd_ndt_cpp_type_for(obj);
   obj_as_tp.swap(*reinterpret_cast<ndt::type *>(out));
 }
 
-inline void convert_one_pyscalar_option(const ndt::type &tp,
-                                        const char *arrmeta, char *out,
-                                        PyObject *obj)
+inline void convert_one_pyscalar_option(const ndt::type &tp, const char *arrmeta, char *out, PyObject *obj)
 {
   if (obj == Py_None) {
     nd::old_assign_na(tp, arrmeta, out);
@@ -192,8 +173,7 @@ inline void convert_one_pyscalar_option(const ndt::type &tp,
 }
 
 template <convert_one_pyscalar_function_t ConvertOneFn>
-static void fill_array_from_pylist(const ndt::type &tp, const char *arrmeta,
-                                   char *data, PyObject *obj,
+static void fill_array_from_pylist(const ndt::type &tp, const char *arrmeta, char *data, PyObject *obj,
                                    const intptr_t *shape, size_t current_axis)
 {
   if (shape[current_axis] == 0) {
@@ -205,8 +185,7 @@ static void fill_array_from_pylist(const ndt::type &tp, const char *arrmeta,
   ndt::type element_tp = tp.at_single(0, &element_arrmeta);
   if (shape[current_axis] >= 0) {
     // Fixed-sized dimension
-    const fixed_dim_type_arrmeta *md =
-        reinterpret_cast<const fixed_dim_type_arrmeta *>(arrmeta);
+    const fixed_dim_type_arrmeta *md = reinterpret_cast<const fixed_dim_type_arrmeta *>(arrmeta);
     intptr_t stride = md->stride;
     if (element_tp.is_scalar()) {
       for (Py_ssize_t i = 0; i < size; ++i) {
@@ -217,8 +196,7 @@ static void fill_array_from_pylist(const ndt::type &tp, const char *arrmeta,
     }
     else {
       for (Py_ssize_t i = 0; i < size; ++i) {
-        fill_array_from_pylist<ConvertOneFn>(element_tp, element_arrmeta, data,
-                                             PyList_GET_ITEM(obj, i), shape,
+        fill_array_from_pylist<ConvertOneFn>(element_tp, element_arrmeta, data, PyList_GET_ITEM(obj, i), shape,
                                              current_axis + 1);
         data += stride;
       }
@@ -226,11 +204,9 @@ static void fill_array_from_pylist(const ndt::type &tp, const char *arrmeta,
   }
   else {
     // Variable-sized dimension
-    const ndt::var_dim_type::metadata_type *md =
-        reinterpret_cast<const ndt::var_dim_type::metadata_type *>(arrmeta);
+    const ndt::var_dim_type::metadata_type *md = reinterpret_cast<const ndt::var_dim_type::metadata_type *>(arrmeta);
     intptr_t stride = md->stride;
-    ndt::var_dim_type::data_type *out =
-        reinterpret_cast<ndt::var_dim_type::data_type *>(data);
+    ndt::var_dim_type::data_type *out = reinterpret_cast<ndt::var_dim_type::data_type *>(data);
     char *out_end = NULL;
 
     out->begin = md->blockref->alloc(size);
@@ -246,9 +222,8 @@ static void fill_array_from_pylist(const ndt::type &tp, const char *arrmeta,
     }
     else {
       for (Py_ssize_t i = 0; i < size; ++i) {
-        fill_array_from_pylist<ConvertOneFn>(
-            element_tp, element_arrmeta, element_data, PyList_GET_ITEM(obj, i),
-            shape, current_axis + 1);
+        fill_array_from_pylist<ConvertOneFn>(element_tp, element_arrmeta, element_data, PyList_GET_ITEM(obj, i), shape,
+                                             current_axis + 1);
         element_data += stride;
       }
     }
@@ -273,87 +248,72 @@ static dynd::nd::array array_from_pylist(PyObject *obj)
   }
 
   // Create the array
-  nd::array result =
-      pydynd::make_strided_array(tp, (int)shape.size(), &shape[0]);
+  nd::array result = pydynd::make_strided_array(tp, (int)shape.size(), &shape[0]);
 
   // Populate the array with data
   switch (tp.get_id()) {
   case bool_id:
-    fill_array_from_pylist<convert_one_pyscalar_bool>(
-        result.get_type(), result.get()->metadata(), result.data(), obj,
-        &shape[0], 0);
+    fill_array_from_pylist<convert_one_pyscalar_bool>(result.get_type(), result.get()->metadata(), result.data(), obj,
+                                                      &shape[0], 0);
     break;
   case int32_id:
-    fill_array_from_pylist<convert_one_pyscalar_int32>(
-        result.get_type(), result.get()->metadata(), result.data(), obj,
-        &shape[0], 0);
+    fill_array_from_pylist<convert_one_pyscalar_int32>(result.get_type(), result.get()->metadata(), result.data(), obj,
+                                                       &shape[0], 0);
     break;
   case int64_id:
-    fill_array_from_pylist<convert_one_pyscalar_int64>(
-        result.get_type(), result.get()->metadata(), result.data(), obj,
-        &shape[0], 0);
+    fill_array_from_pylist<convert_one_pyscalar_int64>(result.get_type(), result.get()->metadata(), result.data(), obj,
+                                                       &shape[0], 0);
     break;
   case float32_id:
-    fill_array_from_pylist<convert_one_pyscalar_float32>(
-        result.get_type(), result.get()->metadata(), result.data(), obj,
-        &shape[0], 0);
+    fill_array_from_pylist<convert_one_pyscalar_float32>(result.get_type(), result.get()->metadata(), result.data(),
+                                                         obj, &shape[0], 0);
     break;
   case float64_id:
-    fill_array_from_pylist<convert_one_pyscalar_float64>(
-        result.get_type(), result.get()->metadata(), result.data(), obj,
-        &shape[0], 0);
+    fill_array_from_pylist<convert_one_pyscalar_float64>(result.get_type(), result.get()->metadata(), result.data(),
+                                                         obj, &shape[0], 0);
     break;
   case complex_float64_id:
-    fill_array_from_pylist<convert_one_pyscalar_cdouble>(
-        result.get_type(), result.get()->metadata(), result.data(), obj,
-        &shape[0], 0);
+    fill_array_from_pylist<convert_one_pyscalar_cdouble>(result.get_type(), result.get()->metadata(), result.data(),
+                                                         obj, &shape[0], 0);
     break;
   case bytes_id:
-    fill_array_from_pylist<convert_one_pyscalar_bytes>(
-        result.get_type(), result.get()->metadata(), result.data(), obj,
-        &shape[0], 0);
+    fill_array_from_pylist<convert_one_pyscalar_bytes>(result.get_type(), result.get()->metadata(), result.data(), obj,
+                                                       &shape[0], 0);
     break;
   case string_id: {
     const ndt::base_string_type *ext = tp.extended<ndt::base_string_type>();
     if (ext->get_encoding() == string_encoding_utf_8) {
-      fill_array_from_pylist<convert_one_pyscalar_ustring>(
-          result.get_type(), result.get()->metadata(), result.data(), obj,
-          &shape[0], 0);
+      fill_array_from_pylist<convert_one_pyscalar_ustring>(result.get_type(), result.get()->metadata(), result.data(),
+                                                           obj, &shape[0], 0);
     }
     else {
       stringstream ss;
-      ss << "Internal error: deduced type from Python list, " << tp
-         << ", doesn't have a dynd array conversion";
+      ss << "Internal error: deduced type from Python list, " << tp << ", doesn't have a dynd array conversion";
       throw runtime_error(ss.str());
     }
     break;
   }
   case type_id: {
-    fill_array_from_pylist<convert_one_pyscalar__type>(
-        result.get_type(), result.get()->metadata(), result.data(), obj,
-        &shape[0], 0);
+    fill_array_from_pylist<convert_one_pyscalar__type>(result.get_type(), result.get()->metadata(), result.data(), obj,
+                                                       &shape[0], 0);
     break;
   }
   case option_id: {
-    fill_array_from_pylist<convert_one_pyscalar_option>(
-        result.get_type(), result.get()->metadata(), result.data(), obj,
-        &shape[0], 0);
+    fill_array_from_pylist<convert_one_pyscalar_option>(result.get_type(), result.get()->metadata(), result.data(), obj,
+                                                        &shape[0], 0);
     break;
   }
   default: {
     stringstream ss;
-    ss << "Deduced type from Python list, " << tp
-       << ", doesn't have a dynd array conversion function yet";
+    ss << "Deduced type from Python list, " << tp << ", doesn't have a dynd array conversion function yet";
     throw runtime_error(ss.str());
   }
   }
-  result.get_type().extended()->arrmeta_finalize_buffers(
-      result.get()->metadata());
+  result.get_type().extended()->arrmeta_finalize_buffers(result.get()->metadata());
   return result;
 }
 
-dynd::nd::array pydynd::array_from_py(PyObject *obj, uint32_t access_flags,
-                                      bool always_copy)
+dynd::nd::array pydynd::array_from_py(PyObject *obj, uint32_t access_flags, bool always_copy)
 {
   // If it's a Cython w_array
   if (PyObject_TypeCheck(obj, get_array_pytypeobject())) {
@@ -364,13 +324,10 @@ dynd::nd::array pydynd::array_from_py(PyObject *obj, uint32_t access_flags,
     else {
       if (access_flags != 0) {
         uint32_t raf = result.get_access_flags();
-        if ((access_flags & nd::immutable_access_flag) &&
-            !(raf & nd::immutable_access_flag)) {
-          throw runtime_error(
-              "cannot view a non-immutable dynd array as immutable");
+        if ((access_flags & nd::immutable_access_flag) && !(raf & nd::immutable_access_flag)) {
+          throw runtime_error("cannot view a non-immutable dynd array as immutable");
         }
-        if ((access_flags & nd::write_access_flag) &&
-            !(raf & nd::write_access_flag)) {
+        if ((access_flags & nd::write_access_flag) && !(raf & nd::write_access_flag)) {
           throw runtime_error("cannot view a readonly dynd array as readwrite");
         }
       }
@@ -380,8 +337,7 @@ dynd::nd::array pydynd::array_from_py(PyObject *obj, uint32_t access_flags,
 
 #if DYND_NUMPY_INTEROP
   if (PyArray_Check(obj)) {
-    return array_from_numpy_array((PyArrayObject *)obj, access_flags,
-                                  always_copy);
+    return array_from_numpy_array((PyArrayObject *)obj, access_flags, always_copy);
   }
   else if (PyArray_IsScalar(obj, Generic)) {
     return array_from_numpy_scalar(obj, access_flags);
@@ -427,8 +383,7 @@ dynd::nd::array pydynd::array_from_py(PyObject *obj, uint32_t access_flags,
     result = nd::array(PyFloat_AS_DOUBLE(obj));
   }
   else if (PyComplex_Check(obj)) {
-    result = nd::array(dynd::complex<double>(PyComplex_RealAsDouble(obj),
-                                             PyComplex_ImagAsDouble(obj)));
+    result = nd::array(dynd::complex<double>(PyComplex_RealAsDouble(obj), PyComplex_ImagAsDouble(obj)));
 #if PY_VERSION_HEX < 0x03000000
   }
   else if (PyString_Check(obj)) {
@@ -441,8 +396,7 @@ dynd::nd::array pydynd::array_from_py(PyObject *obj, uint32_t access_flags,
     for (Py_ssize_t i = 0; i < len; ++i) {
       // Only let valid ascii get through
       if ((unsigned char)data[i] >= 128) {
-        throw string_decode_error(data + i, data + i + 1,
-                                  string_encoding_ascii);
+        throw string_decode_error(data + i, data + i + 1, string_encoding_ascii);
       }
     }
     result = nd::empty(ndt::make_type<ndt::string_type>());
@@ -467,8 +421,7 @@ dynd::nd::array pydynd::array_from_py(PyObject *obj, uint32_t access_flags,
         return result;
       }
       else {
-        throw runtime_error(
-            "cannot create a writable view of a python bytes object");
+        throw runtime_error("cannot create a writable view of a python bytes object");
       }
     }
 
@@ -481,16 +434,14 @@ dynd::nd::array pydynd::array_from_py(PyObject *obj, uint32_t access_flags,
     // Python bytes are immutable, so simply use the existing memory with an
     // external memory
     Py_INCREF(obj);
-    intrusive_ptr<memory_block_data> bytesref = make_external_memory_block(
-        reinterpret_cast<void *>(obj), &py_decref_function);
+    intrusive_ptr<memory_block_data> bytesref =
+        make_external_memory_block(reinterpret_cast<void *>(obj), &py_decref_function);
     char *data_ptr;
-    result =
-        nd::array(reinterpret_cast<dynd::array_preamble *>(
-                      make_array_memory_block(d, d.extended()->get_arrmeta_size(),
-                                              d.get_data_size(),
-                                              d.get_data_alignment(), &data_ptr)
-                          .get()),
-                  true);
+    result = nd::array(reinterpret_cast<dynd::array_preamble *>(
+                           make_array_memory_block(d, d.extended()->get_arrmeta_size(), d.get_data_size(),
+                                                   d.get_data_alignment(), &data_ptr)
+                               .get()),
+                       true);
     result.get()->data = data_ptr;
     result.get()->owner = NULL;
     // The scalar consists of pointers to the byte string data
@@ -543,54 +494,4 @@ dynd::nd::array pydynd::array_from_py(PyObject *obj, uint32_t access_flags,
   }
 
   return result;
-}
-
-dynd::ndt::type pydynd::xtype_for_prefix(PyObject *obj)
-{
-  // If it's a Cython w_array
-  if (PyObject_TypeCheck(obj, get_array_pytypeobject())) {
-    return pydynd::array_to_cpp_ref(obj).get_type();
-  }
-
-#if DYND_NUMPY_INTEROP
-  if (PyArray_Check(obj)) {
-    return array_from_numpy_array2((PyArrayObject *)obj);
-  }
-
-#endif // DYND_NUMPY_INTEROP
-  if (PyBool_Check(obj)) {
-    return ndt::make_type<bool>();
-  }
-#if PY_VERSION_HEX < 0x03000000
-  if (PyInt_Check(obj)) {
-    long value = PyInt_AS_LONG(obj);
-#if SIZEOF_LONG > SIZEOF_INT
-    // Use a 32-bit int if it fits.
-    if (value >= INT_MIN && value <= INT_MAX) {
-      return ndt::make_type<int>();
-    }
-    else {
-      return ndt::make_type<long>();
-    }
-#else
-    return ndt::make_type<long>();
-#endif
-  }
-#endif // PY_VERSION_HEX < 0x03000000
-  if (PyLong_Check(obj)) {
-    PY_LONG_LONG value = PyLong_AsLongLong(obj);
-    if (value == -1 && PyErr_Occurred()) {
-      throw runtime_error("error converting int value");
-    }
-
-    // Use a 32-bit int if it fits.
-    if (value >= INT_MIN && value <= INT_MAX) {
-      return ndt::make_type<int>();
-    }
-    else {
-      return ndt::make_type<PY_LONG_LONG>();
-    }
-  }
-
-  return dynd::ndt::type();
 }

--- a/dynd/src/init.cpp
+++ b/dynd/src/init.cpp
@@ -4,7 +4,7 @@
 //
 
 #define NUMPY_IMPORT_ARRAY
-#include "numpy_interop.hpp"
+#include "numpy_interop_defines.hpp"
 
 #include "assign.hpp"
 #include "init.hpp"

--- a/dynd/src/numpy_interop.cpp
+++ b/dynd/src/numpy_interop.cpp
@@ -8,18 +8,15 @@
 #if DYND_NUMPY_INTEROP
 
 #include <dynd/memblock/external_memory_block.hpp>
-#include <dynd/types/struct_type.hpp>
 
 #include "array_functions.hpp"
 #include "copy_from_numpy_arrfunc.hpp"
-#include "utility_functions.hpp"
 
 #include <numpy/arrayscalars.h>
 
 using namespace std;
 
-void pydynd::fill_arrmeta_from_numpy_dtype(const dynd::ndt::type &dt,
-                                           PyArray_Descr *d, char *arrmeta)
+void pydynd::fill_arrmeta_from_numpy_dtype(const dynd::ndt::type &dt, PyArray_Descr *d, char *arrmeta)
 {
   switch (dt.get_id()) {
   case dynd::struct_id: {
@@ -43,8 +40,7 @@ void pydynd::fill_arrmeta_from_numpy_dtype(const dynd::ndt::type &dt,
       // Fill the arrmeta for the field, if necessary
       const dynd::ndt::type &ft = sdt->get_field_type(i);
       if (!ft.is_builtin()) {
-        fill_arrmeta_from_numpy_dtype(ft, fld_dtype,
-                                      arrmeta + arrmeta_offsets[i]);
+        fill_arrmeta_from_numpy_dtype(ft, fld_dtype, arrmeta + arrmeta_offsets[i]);
       }
     }
     break;
@@ -62,13 +58,11 @@ void pydynd::fill_arrmeta_from_numpy_dtype(const dynd::ndt::type &dt,
     }
     if (PyTuple_Check(adescr->shape)) {
       int ndim = (int)PyTuple_GET_SIZE(adescr->shape);
-      dynd::fixed_dim_type_arrmeta *md =
-          reinterpret_cast<dynd::fixed_dim_type_arrmeta *>(arrmeta);
+      dynd::fixed_dim_type_arrmeta *md = reinterpret_cast<dynd::fixed_dim_type_arrmeta *>(arrmeta);
       intptr_t stride = adescr->base->elsize;
       el = dt;
       for (int i = ndim - 1; i >= 0; --i) {
-        md[i].dim_size =
-            pydynd::pyobject_as_index(PyTuple_GET_ITEM(adescr->shape, i));
+        md[i].dim_size = pydynd::pyobject_as_index(PyTuple_GET_ITEM(adescr->shape, i));
         md[i].stride = stride;
         stride *= md[i].dim_size;
         el = el.extended<dynd::ndt::fixed_dim_type>()->get_element_type();
@@ -76,8 +70,7 @@ void pydynd::fill_arrmeta_from_numpy_dtype(const dynd::ndt::type &dt,
       arrmeta += ndim * sizeof(dynd::fixed_dim_type_arrmeta);
     }
     else {
-      dynd::fixed_dim_type_arrmeta *md =
-          reinterpret_cast<dynd::fixed_dim_type_arrmeta *>(arrmeta);
+      dynd::fixed_dim_type_arrmeta *md = reinterpret_cast<dynd::fixed_dim_type_arrmeta *>(arrmeta);
       arrmeta += sizeof(dynd::fixed_dim_type_arrmeta);
       md->dim_size = pydynd::pyobject_as_index(adescr->shape);
       md->stride = adescr->base->elsize;
@@ -94,400 +87,11 @@ void pydynd::fill_arrmeta_from_numpy_dtype(const dynd::ndt::type &dt,
   }
 }
 
-PyArray_Descr *pydynd::numpy_dtype_from__type(const dynd::ndt::type &tp)
-{
-  switch (tp.get_id()) {
-  case dynd::bool_id:
-    return PyArray_DescrFromType(NPY_BOOL);
-  case dynd::int8_id:
-    return PyArray_DescrFromType(NPY_INT8);
-  case dynd::int16_id:
-    return PyArray_DescrFromType(NPY_INT16);
-  case dynd::int32_id:
-    return PyArray_DescrFromType(NPY_INT32);
-  case dynd::int64_id:
-    return PyArray_DescrFromType(NPY_INT64);
-  case dynd::uint8_id:
-    return PyArray_DescrFromType(NPY_UINT8);
-  case dynd::uint16_id:
-    return PyArray_DescrFromType(NPY_UINT16);
-  case dynd::uint32_id:
-    return PyArray_DescrFromType(NPY_UINT32);
-  case dynd::uint64_id:
-    return PyArray_DescrFromType(NPY_UINT64);
-  case dynd::float32_id:
-    return PyArray_DescrFromType(NPY_FLOAT32);
-  case dynd::float64_id:
-    return PyArray_DescrFromType(NPY_FLOAT64);
-  case dynd::complex_float32_id:
-    return PyArray_DescrFromType(NPY_CFLOAT);
-  case dynd::complex_float64_id:
-    return PyArray_DescrFromType(NPY_CDOUBLE);
-  case dynd::fixed_string_id: {
-    const dynd::ndt::fixed_string_type *ftp =
-        tp.extended<dynd::ndt::fixed_string_type>();
-    PyArray_Descr *result;
-    switch (ftp->get_encoding()) {
-    case dynd::string_encoding_ascii:
-      result = PyArray_DescrNewFromType(NPY_STRING);
-      result->elsize = (int)ftp->get_data_size();
-      return result;
-    case dynd::string_encoding_utf_32:
-      result = PyArray_DescrNewFromType(NPY_UNICODE);
-      result->elsize = (int)ftp->get_data_size();
-      return result;
-    default:
-      break;
-    }
-    break;
-  }
-  /*
-        case tuple_id: {
-            const tuple_type *ttp = tp.extended<tuple_type>();
-            const vector<ndt::type>& fields = ttp->get_fields();
-            size_t num_fields = fields.size();
-            const vector<size_t>& offsets = ttp->get_offsets();
-            // TODO: Deal with the names better
-            pyobject_ownref names_obj(PyList_New(num_fields));
-            for (size_t i = 0; i < num_fields; ++i) {
-                stringstream ss;
-                ss << "f" << i;
-                PyList_SET_ITEM((PyObject *)names_obj, i,
-PyString_FromString(ss.str().c_str()));
-            }
-            pyobject_ownref formats_obj(PyList_New(num_fields));
-            for (size_t i = 0; i < num_fields; ++i) {
-                PyList_SET_ITEM((PyObject *)formats_obj, i, (PyObject
-*)numpy_dtype_from__type(fields[i]));
-            }
-            pyobject_ownref offsets_obj(PyList_New(num_fields));
-            for (size_t i = 0; i < num_fields; ++i) {
-                PyList_SET_ITEM((PyObject *)offsets_obj, i,
-PyLong_FromSize_t(offsets[i]));
-            }
-            pyobject_ownref itemsize_obj(PyLong_FromSize_t(tp.get_data_size()));
-            pyobject_ownref dict_obj(PyDict_New());
-            PyDict_SetItemString(dict_obj, "names", names_obj);
-            PyDict_SetItemString(dict_obj, "formats", formats_obj);
-            PyDict_SetItemString(dict_obj, "offsets", offsets_obj);
-            PyDict_SetItemString(dict_obj, "itemsize", itemsize_obj);
-            PyArray_Descr *result = NULL;
-            if (PyArray_DescrConverter(dict_obj, &result) != NPY_SUCCEED) {
-                throw dynd::type_error("failed to convert tuple dtype into numpy
-dtype via dict");
-            }
-            return result;
-        }
-        case struct_id: {
-            const struct_type *ttp = tp.extended<struct_type>();
-            size_t field_count = ttp->get_field_count();
-            size_t max_numpy_alignment = 1;
-            std::vector<uintptr_t> offsets(field_count);
-            struct_type::fill_default_data_offsets(field_count,
-ttp->get_field_types_raw(), offsets.data());
-            pyobject_ownref names_obj(PyList_New(field_count));
-            for (size_t i = 0; i < field_count; ++i) {
-                const string_type_data& fname = ttp->get_field_name(i);
-#if PY_VERSION_HEX >= 0x03000000
-                pyobject_ownref name_str(PyUnicode_FromStringAndSize(
-                    fname.begin, fname.end - fname.begin));
-#else
-                pyobject_ownref name_str(PyString_FromStringAndSize(
-                    fname.begin, fname.end - fname.begin));
-#endif
-                PyList_SET_ITEM((PyObject *)names_obj, i, name_str.release());
-            }
-            pyobject_ownref formats_obj(PyList_New(field_count));
-            for (size_t i = 0; i < field_count; ++i) {
-                PyArray_Descr *npdt =
-numpy_dtype_from__type(ttp->get_field_type(i));
-                max_numpy_alignment = max(max_numpy_alignment,
-(size_t)npdt->alignment);
-                PyList_SET_ITEM((PyObject *)formats_obj, i, (PyObject *)npdt);
-            }
-            pyobject_ownref offsets_obj(PyList_New(field_count));
-            for (size_t i = 0; i < field_count; ++i) {
-                PyList_SET_ITEM((PyObject *)offsets_obj, i,
-PyLong_FromSize_t(offsets[i]));
-            }
-            pyobject_ownref
-itemsize_obj(PyLong_FromSize_t(tp.get_default_data_size()));
-            pyobject_ownref dict_obj(PyDict_New());
-            PyDict_SetItemString(dict_obj, "names", names_obj);
-            PyDict_SetItemString(dict_obj, "formats", formats_obj);
-            PyDict_SetItemString(dict_obj, "offsets", offsets_obj);
-            PyDict_SetItemString(dict_obj, "itemsize", itemsize_obj);
-            // This isn't quite right, but the rules between numpy and dynd
-            // differ enough to make this tricky.
-            if (max_numpy_alignment > 1 &&
-                            max_numpy_alignment == tp.get_data_alignment()) {
-                Py_INCREF(Py_True);
-                PyDict_SetItemString(dict_obj, "aligned", Py_True);
-            }
-            PyArray_Descr *result = NULL;
-            if (PyArray_DescrConverter(dict_obj, &result) != NPY_SUCCEED) {
-                stringstream ss;
-                ss << "failed to convert dtype " << tp << " into numpy dtype via
-dict";
-                throw dynd::type_error(ss.str());
-            }
-            return result;
-        }
-        case fixed_dim_id: {
-            ndt::type child_tp = tp;
-            vector<intptr_t> shape;
-            do {
-                const cfixed_dim_type *ttp =
-child_tp.extended<cfixed_dim_type>();
-                shape.push_back(ttp->get_fixed_dim_size());
-                if (child_tp.get_data_size() !=
-ttp->get_element_type().get_data_size() * shape.back()) {
-                    stringstream ss;
-                    ss << "Cannot convert dynd type " << tp << " into a numpy
-dtype because it is not C-order";
-                    throw dynd::type_error(ss.str());
-                }
-                child_tp = ttp->get_element_type();
-            } while (child_tp.get_id() == cfixed_dim_id);
-            pyobject_ownref dtype_obj((PyObject
-*)numpy_dtype_from__type(child_tp));
-            pyobject_ownref shape_obj(intptr_array_as_tuple((int)shape.size(),
-&shape[0]));
-            pyobject_ownref tuple_obj(PyTuple_New(2));
-            PyTuple_SET_ITEM(tuple_obj.get(), 0, dtype_obj.release());
-            PyTuple_SET_ITEM(tuple_obj.get(), 1, shape_obj.release());
-            PyArray_Descr *result = NULL;
-            if (PyArray_DescrConverter(tuple_obj, &result) != NPY_SUCCEED) {
-                throw dynd::type_error("failed to convert dynd type into numpy
-subarray dtype");
-            }
-            return result;
-        }
-*/
-  default:
-    break;
-  }
-
-  stringstream ss;
-  ss << "cannot convert dynd type " << tp << " into a Numpy dtype";
-  throw dynd::type_error(ss.str());
-}
-
-PyArray_Descr *pydynd::numpy_dtype_from__type(const dynd::ndt::type &tp,
-                                              const char *arrmeta)
-{
-  switch (tp.get_id()) {
-  case dynd::struct_id: {
-    throw std::runtime_error("converting");
-    if (arrmeta == NULL) {
-      stringstream ss;
-      ss << "Can only convert dynd type " << tp
-         << " into a numpy dtype with array arrmeta";
-      throw dynd::type_error(ss.str());
-    }
-    const dynd::ndt::struct_type *stp = tp.extended<dynd::ndt::struct_type>();
-    const uintptr_t *arrmeta_offsets = stp->get_arrmeta_offsets_raw();
-    const uintptr_t *offsets = reinterpret_cast<const uintptr_t *>(arrmeta);
-    size_t field_count = stp->get_field_count();
-    size_t max_numpy_alignment = 1;
-
-    pyobject_ownref names_obj(PyList_New(field_count));
-    for (size_t i = 0; i < field_count; ++i) {
-      const dynd::string &fname = stp->get_field_name(i);
-#if PY_VERSION_HEX >= 0x03000000
-      pyobject_ownref name_str(PyUnicode_FromStringAndSize(
-          fname.begin(), fname.end() - fname.begin()));
-#else
-      pyobject_ownref name_str(PyString_FromStringAndSize(
-          fname.begin(), fname.end() - fname.begin()));
-#endif
-      PyList_SET_ITEM((PyObject *)names_obj, i, name_str.release());
-    }
-
-    pyobject_ownref formats_obj(PyList_New(field_count));
-    for (size_t i = 0; i < field_count; ++i) {
-      PyArray_Descr *npdt = numpy_dtype_from__type(
-          stp->get_field_type(i), arrmeta + arrmeta_offsets[i]);
-      max_numpy_alignment = max(max_numpy_alignment, (size_t)npdt->alignment);
-      PyList_SET_ITEM((PyObject *)formats_obj, i, (PyObject *)npdt);
-    }
-
-    pyobject_ownref offsets_obj(PyList_New(field_count));
-    for (size_t i = 0; i < field_count; ++i) {
-      PyList_SET_ITEM((PyObject *)offsets_obj, i,
-                      PyLong_FromSize_t(offsets[i]));
-    }
-
-    pyobject_ownref itemsize_obj(PyLong_FromSize_t(tp.get_data_size()));
-
-    pyobject_ownref dict_obj(PyDict_New());
-    PyDict_SetItemString(dict_obj, "names", names_obj);
-    PyDict_SetItemString(dict_obj, "formats", formats_obj);
-    PyDict_SetItemString(dict_obj, "offsets", offsets_obj);
-    PyDict_SetItemString(dict_obj, "itemsize", itemsize_obj);
-    // This isn't quite right, but the rules between numpy and dynd
-    // differ enough to make this tricky.
-    if (max_numpy_alignment > 1 &&
-        max_numpy_alignment == tp.get_data_alignment()) {
-      Py_INCREF(Py_True);
-      PyDict_SetItemString(dict_obj, "aligned", Py_True);
-    }
-
-    PyArray_Descr *result = NULL;
-    if (PyArray_DescrConverter(dict_obj, &result) != NPY_SUCCEED) {
-      throw dynd::type_error(
-          "failed to convert dtype into numpy struct dtype via dict");
-    }
-    return result;
-  }
-  default:
-    return numpy_dtype_from__type(tp);
-  }
-}
-
-int pydynd::_type_from_numpy_scalar_typeobject(PyTypeObject *obj,
-                                               dynd::ndt::type &out_d)
-{
-  if (obj == &PyBoolArrType_Type) {
-    out_d = dynd::ndt::make_type<dynd::bool1>();
-  }
-  else if (obj == &PyByteArrType_Type) {
-    out_d = dynd::ndt::make_type<npy_byte>();
-  }
-  else if (obj == &PyUByteArrType_Type) {
-    out_d = dynd::ndt::make_type<npy_ubyte>();
-  }
-  else if (obj == &PyShortArrType_Type) {
-    out_d = dynd::ndt::make_type<npy_short>();
-  }
-  else if (obj == &PyUShortArrType_Type) {
-    out_d = dynd::ndt::make_type<npy_ushort>();
-  }
-  else if (obj == &PyIntArrType_Type) {
-    out_d = dynd::ndt::make_type<npy_int>();
-  }
-  else if (obj == &PyUIntArrType_Type) {
-    out_d = dynd::ndt::make_type<npy_uint>();
-  }
-  else if (obj == &PyLongArrType_Type) {
-    out_d = dynd::ndt::make_type<npy_long>();
-  }
-  else if (obj == &PyULongArrType_Type) {
-    out_d = dynd::ndt::make_type<npy_ulong>();
-  }
-  else if (obj == &PyLongLongArrType_Type) {
-    out_d = dynd::ndt::make_type<npy_longlong>();
-  }
-  else if (obj == &PyULongLongArrType_Type) {
-    out_d = dynd::ndt::make_type<npy_ulonglong>();
-  }
-  else if (obj == &PyFloatArrType_Type) {
-    out_d = dynd::ndt::make_type<npy_float>();
-  }
-  else if (obj == &PyDoubleArrType_Type) {
-    out_d = dynd::ndt::make_type<npy_double>();
-  }
-  else if (obj == &PyCFloatArrType_Type) {
-    out_d = dynd::ndt::make_type<dynd::complex<float>>();
-  }
-  else if (obj == &PyCDoubleArrType_Type) {
-    out_d = dynd::ndt::make_type<dynd::complex<double>>();
-  }
-  else {
-    return -1;
-  }
-
-  return 0;
-}
-
-dynd::ndt::type pydynd::_type_of_numpy_scalar(PyObject *obj)
-{
-  if (PyArray_IsScalar(obj, Bool)) {
-    return dynd::ndt::make_type<dynd::bool1>();
-  }
-  else if (PyArray_IsScalar(obj, Byte)) {
-    return dynd::ndt::make_type<npy_byte>();
-  }
-  else if (PyArray_IsScalar(obj, UByte)) {
-    return dynd::ndt::make_type<npy_ubyte>();
-  }
-  else if (PyArray_IsScalar(obj, Short)) {
-    return dynd::ndt::make_type<npy_short>();
-  }
-  else if (PyArray_IsScalar(obj, UShort)) {
-    return dynd::ndt::make_type<npy_ushort>();
-  }
-  else if (PyArray_IsScalar(obj, Int)) {
-    return dynd::ndt::make_type<npy_int>();
-  }
-  else if (PyArray_IsScalar(obj, UInt)) {
-    return dynd::ndt::make_type<npy_uint>();
-  }
-  else if (PyArray_IsScalar(obj, Long)) {
-    return dynd::ndt::make_type<npy_long>();
-  }
-  else if (PyArray_IsScalar(obj, ULong)) {
-    return dynd::ndt::make_type<npy_ulong>();
-  }
-  else if (PyArray_IsScalar(obj, LongLong)) {
-    return dynd::ndt::make_type<npy_longlong>();
-  }
-  else if (PyArray_IsScalar(obj, ULongLong)) {
-    return dynd::ndt::make_type<npy_ulonglong>();
-  }
-  else if (PyArray_IsScalar(obj, Float)) {
-    return dynd::ndt::make_type<float>();
-  }
-  else if (PyArray_IsScalar(obj, Double)) {
-    return dynd::ndt::make_type<double>();
-  }
-  else if (PyArray_IsScalar(obj, CFloat)) {
-    return dynd::ndt::make_type<dynd::complex<float>>();
-  }
-  else if (PyArray_IsScalar(obj, CDouble)) {
-    return dynd::ndt::make_type<dynd::complex<double>>();
-  }
-
-  throw dynd::type_error(
-      "could not deduce a pydynd type from the numpy scalar object");
-}
-
-inline size_t get_alignment_of(uintptr_t align_bits)
-{
-  size_t alignment = 1;
-  // Loop 4 times, maximum alignment of 16
-  for (int i = 0; i < 4; ++i) {
-    if ((align_bits & alignment) == 0) {
-      alignment <<= 1;
-    }
-    else {
-      return alignment;
-    }
-  }
-  return alignment;
-}
-
-inline size_t get_alignment_of(PyArrayObject *obj)
-{
-  // Get the alignment of the data
-  uintptr_t align_bits = reinterpret_cast<uintptr_t>(PyArray_DATA(obj));
-  int ndim = PyArray_NDIM(obj);
-  intptr_t *strides = PyArray_STRIDES(obj);
-  for (int idim = 0; idim < ndim; ++idim) {
-    align_bits |= (uintptr_t)strides[idim];
-  }
-
-  return get_alignment_of(align_bits);
-}
-
-dynd::nd::array pydynd::array_from_numpy_array(PyArrayObject *obj,
-                                               uint32_t access_flags,
-                                               bool always_copy)
+dynd::nd::array pydynd::array_from_numpy_array(PyArrayObject *obj, uint32_t access_flags, bool always_copy)
 {
   // If a copy isn't requested, make sure the access flags are ok
   if (!always_copy) {
-    if ((access_flags & dynd::nd::write_access_flag) &&
-        !PyArray_ISWRITEABLE(obj)) {
+    if ((access_flags & dynd::nd::write_access_flag) && !PyArray_ISWRITEABLE(obj)) {
       throw runtime_error("cannot view a readonly numpy array as readwrite");
     }
     if (access_flags & dynd::nd::immutable_access_flag) {
@@ -501,12 +105,9 @@ dynd::nd::array pydynd::array_from_numpy_array(PyArrayObject *obj,
     // TODO would be nicer without the extra type transformation of the
     // get_canonical_type call
     dynd::nd::array result = dynd::nd::dtyped_empty(
-        PyArray_NDIM(obj), PyArray_SHAPE(obj),
-        pydynd::_type_from_numpy_dtype(PyArray_DESCR(obj))
-            .get_canonical_type());
-    pydynd::nd::array_copy_from_numpy(result.get_type(),
-                                      result.get()->metadata(), result.data(),
-                                      obj, &dynd::eval::default_eval_context);
+        PyArray_NDIM(obj), PyArray_SHAPE(obj), pydynd::_type_from_numpy_dtype(PyArray_DESCR(obj)).get_canonical_type());
+    pydynd::nd::array_copy_from_numpy(result.get_type(), result.get()->metadata(), result.data(), obj,
+                                      &dynd::eval::default_eval_context);
     if (access_flags != 0) {
       // Use the requested access flags
       result.get()->flags = access_flags;
@@ -518,8 +119,7 @@ dynd::nd::array pydynd::array_from_numpy_array(PyArrayObject *obj,
   }
   else {
     // Get the dtype of the array
-    dynd::ndt::type d = pydynd::_type_from_numpy_dtype(PyArray_DESCR(obj),
-                                                       get_alignment_of(obj));
+    dynd::ndt::type d = pydynd::_type_from_numpy_dtype(PyArray_DESCR(obj), get_alignment_of(obj));
 
     // Get a shared pointer that tracks buffer ownership
     PyObject *base = PyArray_BASE(obj);
@@ -544,9 +144,8 @@ dynd::nd::array pydynd::array_from_numpy_array(PyArrayObject *obj,
     char *arrmeta = NULL;
     dynd::nd::array result = dynd::nd::make_strided_array_from_data(
         d, PyArray_NDIM(obj), PyArray_DIMS(obj), PyArray_STRIDES(obj),
-        dynd::nd::read_access_flag |
-            (PyArray_ISWRITEABLE(obj) ? dynd::nd::write_access_flag : 0),
-        PyArray_BYTES(obj), std::move(memblock), &arrmeta);
+        dynd::nd::read_access_flag | (PyArray_ISWRITEABLE(obj) ? dynd::nd::write_access_flag : 0), PyArray_BYTES(obj),
+        std::move(memblock), &arrmeta);
     if (d.get_id() == dynd::struct_id) {
       // If it's a struct, there's additional arrmeta that needs to be populated
       pydynd::fill_arrmeta_from_numpy_dtype(d, PyArray_DESCR(obj), arrmeta);
@@ -560,30 +159,11 @@ dynd::nd::array pydynd::array_from_numpy_array(PyArrayObject *obj,
   }
 }
 
-dynd::ndt::type pydynd::array_from_numpy_array2(PyArrayObject *obj)
-{
-  PyArray_Descr *dtype = PyArray_DESCR(obj);
-
-  if (PyDataType_FLAGCHK(dtype, NPY_ITEM_HASOBJECT)) {
-    return dynd::ndt::make_fixed_dim(
-        PyArray_NDIM(obj), PyArray_SHAPE(obj),
-        pydynd::_type_from_numpy_dtype(dtype).get_canonical_type());
-  }
-  else {
-    // Get the dtype of the array
-    dynd::ndt::type d = pydynd::_type_from_numpy_dtype(PyArray_DESCR(obj),
-                                                       get_alignment_of(obj));
-    return dynd::ndt::make_fixed_dim(PyArray_NDIM(obj), PyArray_DIMS(obj), d);
-  }
-}
-
-dynd::nd::array pydynd::array_from_numpy_scalar(PyObject *obj,
-                                                uint32_t access_flags)
+dynd::nd::array pydynd::array_from_numpy_scalar(PyObject *obj, uint32_t access_flags)
 {
   dynd::nd::array result;
   if (PyArray_IsScalar(obj, Bool)) {
-    result =
-        dynd::nd::array((dynd::bool1)(((PyBoolScalarObject *)obj)->obval != 0));
+    result = dynd::nd::array((dynd::bool1)(((PyBoolScalarObject *)obj)->obval != 0));
   }
   else if (PyArray_IsScalar(obj, Byte)) {
     result = dynd::nd::array(((PyByteScalarObject *)obj)->obval);
@@ -631,8 +211,7 @@ dynd::nd::array pydynd::array_from_numpy_scalar(PyObject *obj,
   }
   else if (PyArray_IsScalar(obj, Void)) {
     pyobject_ownref arr(PyArray_FromAny(obj, NULL, 0, 0, 0, NULL));
-    return array_from_numpy_array((PyArrayObject *)arr.get(), access_flags,
-                                  true);
+    return array_from_numpy_array((PyArrayObject *)arr.get(), access_flags, true);
   }
   else {
     stringstream ss;
@@ -642,85 +221,9 @@ dynd::nd::array pydynd::array_from_numpy_scalar(PyObject *obj,
     throw dynd::type_error(ss.str());
   }
 
-  result.get()->flags =
-      access_flags ? access_flags : dynd::nd::default_access_flags;
+  result.get()->flags = access_flags ? access_flags : dynd::nd::default_access_flags;
 
   return result;
 }
-
-dynd::ndt::type pydynd::array_from_numpy_scalar2(PyObject *obj)
-{
-  if (PyArray_IsScalar(obj, Bool)) {
-    return dynd::ndt::make_type<bool>();
-  }
-
-  if (PyArray_IsScalar(obj, Byte)) {
-    return dynd::ndt::make_type<signed char>();
-  }
-
-  if (PyArray_IsScalar(obj, UByte)) {
-    return dynd::ndt::make_type<unsigned char>();
-  }
-
-  if (PyArray_IsScalar(obj, Short)) {
-    return dynd::ndt::make_type<short>();
-  }
-
-  if (PyArray_IsScalar(obj, UShort)) {
-    return dynd::ndt::make_type<unsigned short>();
-  }
-
-  if (PyArray_IsScalar(obj, Int)) {
-    return dynd::ndt::make_type<int>();
-  }
-
-  if (PyArray_IsScalar(obj, UInt)) {
-    return dynd::ndt::make_type<unsigned int>();
-  }
-
-  if (PyArray_IsScalar(obj, Long)) {
-    return dynd::ndt::make_type<long>();
-  }
-
-  if (PyArray_IsScalar(obj, ULong)) {
-    return dynd::ndt::make_type<unsigned long>();
-  }
-
-  if (PyArray_IsScalar(obj, LongLong)) {
-    return dynd::ndt::make_type<long long>();
-  }
-
-  if (PyArray_IsScalar(obj, ULongLong)) {
-    return dynd::ndt::make_type<unsigned long long>();
-  }
-
-  if (PyArray_IsScalar(obj, Float)) {
-    return dynd::ndt::make_type<float>();
-  }
-
-  if (PyArray_IsScalar(obj, Double)) {
-    return dynd::ndt::make_type<double>();
-  }
-
-  if (PyArray_IsScalar(obj, CFloat)) {
-    return dynd::ndt::make_type<dynd::complex<float>>();
-  }
-
-  if (PyArray_IsScalar(obj, CDouble)) {
-    return dynd::ndt::make_type<dynd::complex<double>>();
-  }
-
-  if (PyArray_IsScalar(obj, Void)) {
-    return dynd::ndt::make_type<void>();
-  }
-
-  stringstream ss;
-  pyobject_ownref obj_tp(PyObject_Repr((PyObject *)Py_TYPE(obj)));
-  ss << "could not create a dynd array from the numpy scalar object";
-  ss << " of type " << pydynd::pystring_as_string(obj_tp.get());
-  throw dynd::type_error(ss.str());
-}
-
-bool pydynd::is_numpy_dtype(PyObject *o) { return PyArray_DescrCheck(o); }
 
 #endif // DYND_NUMPY_INTEROP

--- a/dynd/src/numpy_type_interop.cpp
+++ b/dynd/src/numpy_type_interop.cpp
@@ -1,0 +1,456 @@
+//
+// Copyright (C) 2011-16 DyND Developers
+// BSD 2-Clause License, see LICENSE.txt
+//
+// This header defines some functions to
+// interoperate with numpy
+//
+
+#include "numpy_type_interop.hpp"
+
+#if DYND_NUMPY_INTEROP
+
+#include <dynd/types/struct_type.hpp>
+
+#include <numpy/arrayscalars.h>
+
+using namespace std;
+
+PyArray_Descr *pydynd::numpy_dtype_from__type(const dynd::ndt::type &tp)
+{
+  switch (tp.get_id()) {
+  case dynd::bool_id:
+    return PyArray_DescrFromType(NPY_BOOL);
+  case dynd::int8_id:
+    return PyArray_DescrFromType(NPY_INT8);
+  case dynd::int16_id:
+    return PyArray_DescrFromType(NPY_INT16);
+  case dynd::int32_id:
+    return PyArray_DescrFromType(NPY_INT32);
+  case dynd::int64_id:
+    return PyArray_DescrFromType(NPY_INT64);
+  case dynd::uint8_id:
+    return PyArray_DescrFromType(NPY_UINT8);
+  case dynd::uint16_id:
+    return PyArray_DescrFromType(NPY_UINT16);
+  case dynd::uint32_id:
+    return PyArray_DescrFromType(NPY_UINT32);
+  case dynd::uint64_id:
+    return PyArray_DescrFromType(NPY_UINT64);
+  case dynd::float32_id:
+    return PyArray_DescrFromType(NPY_FLOAT32);
+  case dynd::float64_id:
+    return PyArray_DescrFromType(NPY_FLOAT64);
+  case dynd::complex_float32_id:
+    return PyArray_DescrFromType(NPY_CFLOAT);
+  case dynd::complex_float64_id:
+    return PyArray_DescrFromType(NPY_CDOUBLE);
+  case dynd::fixed_string_id: {
+    const dynd::ndt::fixed_string_type *ftp = tp.extended<dynd::ndt::fixed_string_type>();
+    PyArray_Descr *result;
+    switch (ftp->get_encoding()) {
+    case dynd::string_encoding_ascii:
+      result = PyArray_DescrNewFromType(NPY_STRING);
+      result->elsize = (int)ftp->get_data_size();
+      return result;
+    case dynd::string_encoding_utf_32:
+      result = PyArray_DescrNewFromType(NPY_UNICODE);
+      result->elsize = (int)ftp->get_data_size();
+      return result;
+    default:
+      break;
+    }
+    break;
+  }
+  /*
+        case tuple_id: {
+            const tuple_type *ttp = tp.extended<tuple_type>();
+            const vector<ndt::type>& fields = ttp->get_fields();
+            size_t num_fields = fields.size();
+            const vector<size_t>& offsets = ttp->get_offsets();
+            // TODO: Deal with the names better
+            pyobject_ownref names_obj(PyList_New(num_fields));
+            for (size_t i = 0; i < num_fields; ++i) {
+                stringstream ss;
+                ss << "f" << i;
+                PyList_SET_ITEM((PyObject *)names_obj, i,
+PyString_FromString(ss.str().c_str()));
+            }
+            pyobject_ownref formats_obj(PyList_New(num_fields));
+            for (size_t i = 0; i < num_fields; ++i) {
+                PyList_SET_ITEM((PyObject *)formats_obj, i, (PyObject
+*)numpy_dtype_from__type(fields[i]));
+            }
+            pyobject_ownref offsets_obj(PyList_New(num_fields));
+            for (size_t i = 0; i < num_fields; ++i) {
+                PyList_SET_ITEM((PyObject *)offsets_obj, i,
+PyLong_FromSize_t(offsets[i]));
+            }
+            pyobject_ownref itemsize_obj(PyLong_FromSize_t(tp.get_data_size()));
+            pyobject_ownref dict_obj(PyDict_New());
+            PyDict_SetItemString(dict_obj, "names", names_obj);
+            PyDict_SetItemString(dict_obj, "formats", formats_obj);
+            PyDict_SetItemString(dict_obj, "offsets", offsets_obj);
+            PyDict_SetItemString(dict_obj, "itemsize", itemsize_obj);
+            PyArray_Descr *result = NULL;
+            if (PyArray_DescrConverter(dict_obj, &result) != NPY_SUCCEED) {
+                throw dynd::type_error("failed to convert tuple dtype into numpy
+dtype via dict");
+            }
+            return result;
+        }
+        case struct_id: {
+            const struct_type *ttp = tp.extended<struct_type>();
+            size_t field_count = ttp->get_field_count();
+            size_t max_numpy_alignment = 1;
+            std::vector<uintptr_t> offsets(field_count);
+            struct_type::fill_default_data_offsets(field_count,
+ttp->get_field_types_raw(), offsets.data());
+            pyobject_ownref names_obj(PyList_New(field_count));
+            for (size_t i = 0; i < field_count; ++i) {
+                const string_type_data& fname = ttp->get_field_name(i);
+#if PY_VERSION_HEX >= 0x03000000
+                pyobject_ownref name_str(PyUnicode_FromStringAndSize(
+                    fname.begin, fname.end - fname.begin));
+#else
+                pyobject_ownref name_str(PyString_FromStringAndSize(
+                    fname.begin, fname.end - fname.begin));
+#endif
+                PyList_SET_ITEM((PyObject *)names_obj, i, name_str.release());
+            }
+            pyobject_ownref formats_obj(PyList_New(field_count));
+            for (size_t i = 0; i < field_count; ++i) {
+                PyArray_Descr *npdt =
+numpy_dtype_from__type(ttp->get_field_type(i));
+                max_numpy_alignment = max(max_numpy_alignment,
+(size_t)npdt->alignment);
+                PyList_SET_ITEM((PyObject *)formats_obj, i, (PyObject *)npdt);
+            }
+            pyobject_ownref offsets_obj(PyList_New(field_count));
+            for (size_t i = 0; i < field_count; ++i) {
+                PyList_SET_ITEM((PyObject *)offsets_obj, i,
+PyLong_FromSize_t(offsets[i]));
+            }
+            pyobject_ownref
+itemsize_obj(PyLong_FromSize_t(tp.get_default_data_size()));
+            pyobject_ownref dict_obj(PyDict_New());
+            PyDict_SetItemString(dict_obj, "names", names_obj);
+            PyDict_SetItemString(dict_obj, "formats", formats_obj);
+            PyDict_SetItemString(dict_obj, "offsets", offsets_obj);
+            PyDict_SetItemString(dict_obj, "itemsize", itemsize_obj);
+            // This isn't quite right, but the rules between numpy and dynd
+            // differ enough to make this tricky.
+            if (max_numpy_alignment > 1 &&
+                            max_numpy_alignment == tp.get_data_alignment()) {
+                Py_INCREF(Py_True);
+                PyDict_SetItemString(dict_obj, "aligned", Py_True);
+            }
+            PyArray_Descr *result = NULL;
+            if (PyArray_DescrConverter(dict_obj, &result) != NPY_SUCCEED) {
+                stringstream ss;
+                ss << "failed to convert dtype " << tp << " into numpy dtype via
+dict";
+                throw dynd::type_error(ss.str());
+            }
+            return result;
+        }
+        case fixed_dim_id: {
+            ndt::type child_tp = tp;
+            vector<intptr_t> shape;
+            do {
+                const cfixed_dim_type *ttp =
+child_tp.extended<cfixed_dim_type>();
+                shape.push_back(ttp->get_fixed_dim_size());
+                if (child_tp.get_data_size() !=
+ttp->get_element_type().get_data_size() * shape.back()) {
+                    stringstream ss;
+                    ss << "Cannot convert dynd type " << tp << " into a numpy
+dtype because it is not C-order";
+                    throw dynd::type_error(ss.str());
+                }
+                child_tp = ttp->get_element_type();
+            } while (child_tp.get_id() == cfixed_dim_id);
+            pyobject_ownref dtype_obj((PyObject
+*)numpy_dtype_from__type(child_tp));
+            pyobject_ownref shape_obj(intptr_array_as_tuple((int)shape.size(),
+&shape[0]));
+            pyobject_ownref tuple_obj(PyTuple_New(2));
+            PyTuple_SET_ITEM(tuple_obj.get(), 0, dtype_obj.release());
+            PyTuple_SET_ITEM(tuple_obj.get(), 1, shape_obj.release());
+            PyArray_Descr *result = NULL;
+            if (PyArray_DescrConverter(tuple_obj, &result) != NPY_SUCCEED) {
+                throw dynd::type_error("failed to convert dynd type into numpy
+subarray dtype");
+            }
+            return result;
+        }
+*/
+  default:
+    break;
+  }
+
+  stringstream ss;
+  ss << "cannot convert dynd type " << tp << " into a Numpy dtype";
+  throw dynd::type_error(ss.str());
+}
+
+PyArray_Descr *pydynd::numpy_dtype_from__type(const dynd::ndt::type &tp, const char *arrmeta)
+{
+  switch (tp.get_id()) {
+  case dynd::struct_id: {
+    throw std::runtime_error("converting");
+    if (arrmeta == NULL) {
+      stringstream ss;
+      ss << "Can only convert dynd type " << tp << " into a numpy dtype with array arrmeta";
+      throw dynd::type_error(ss.str());
+    }
+    const dynd::ndt::struct_type *stp = tp.extended<dynd::ndt::struct_type>();
+    const uintptr_t *arrmeta_offsets = stp->get_arrmeta_offsets_raw();
+    const uintptr_t *offsets = reinterpret_cast<const uintptr_t *>(arrmeta);
+    size_t field_count = stp->get_field_count();
+    size_t max_numpy_alignment = 1;
+
+    pyobject_ownref names_obj(PyList_New(field_count));
+    for (size_t i = 0; i < field_count; ++i) {
+      const dynd::string &fname = stp->get_field_name(i);
+#if PY_VERSION_HEX >= 0x03000000
+      pyobject_ownref name_str(PyUnicode_FromStringAndSize(fname.begin(), fname.end() - fname.begin()));
+#else
+      pyobject_ownref name_str(PyString_FromStringAndSize(fname.begin(), fname.end() - fname.begin()));
+#endif
+      PyList_SET_ITEM((PyObject *)names_obj, i, name_str.release());
+    }
+
+    pyobject_ownref formats_obj(PyList_New(field_count));
+    for (size_t i = 0; i < field_count; ++i) {
+      PyArray_Descr *npdt = numpy_dtype_from__type(stp->get_field_type(i), arrmeta + arrmeta_offsets[i]);
+      max_numpy_alignment = max(max_numpy_alignment, (size_t)npdt->alignment);
+      PyList_SET_ITEM((PyObject *)formats_obj, i, (PyObject *)npdt);
+    }
+
+    pyobject_ownref offsets_obj(PyList_New(field_count));
+    for (size_t i = 0; i < field_count; ++i) {
+      PyList_SET_ITEM((PyObject *)offsets_obj, i, PyLong_FromSize_t(offsets[i]));
+    }
+
+    pyobject_ownref itemsize_obj(PyLong_FromSize_t(tp.get_data_size()));
+
+    pyobject_ownref dict_obj(PyDict_New());
+    PyDict_SetItemString(dict_obj, "names", names_obj);
+    PyDict_SetItemString(dict_obj, "formats", formats_obj);
+    PyDict_SetItemString(dict_obj, "offsets", offsets_obj);
+    PyDict_SetItemString(dict_obj, "itemsize", itemsize_obj);
+    // This isn't quite right, but the rules between numpy and dynd
+    // differ enough to make this tricky.
+    if (max_numpy_alignment > 1 && max_numpy_alignment == tp.get_data_alignment()) {
+      Py_INCREF(Py_True);
+      PyDict_SetItemString(dict_obj, "aligned", Py_True);
+    }
+
+    PyArray_Descr *result = NULL;
+    if (PyArray_DescrConverter(dict_obj, &result) != NPY_SUCCEED) {
+      throw dynd::type_error("failed to convert dtype into numpy struct dtype via dict");
+    }
+    return result;
+  }
+  default:
+    return numpy_dtype_from__type(tp);
+  }
+}
+
+int pydynd::_type_from_numpy_scalar_typeobject(PyTypeObject *obj, dynd::ndt::type &out_d)
+{
+  if (obj == &PyBoolArrType_Type) {
+    out_d = dynd::ndt::make_type<dynd::bool1>();
+  }
+  else if (obj == &PyByteArrType_Type) {
+    out_d = dynd::ndt::make_type<npy_byte>();
+  }
+  else if (obj == &PyUByteArrType_Type) {
+    out_d = dynd::ndt::make_type<npy_ubyte>();
+  }
+  else if (obj == &PyShortArrType_Type) {
+    out_d = dynd::ndt::make_type<npy_short>();
+  }
+  else if (obj == &PyUShortArrType_Type) {
+    out_d = dynd::ndt::make_type<npy_ushort>();
+  }
+  else if (obj == &PyIntArrType_Type) {
+    out_d = dynd::ndt::make_type<npy_int>();
+  }
+  else if (obj == &PyUIntArrType_Type) {
+    out_d = dynd::ndt::make_type<npy_uint>();
+  }
+  else if (obj == &PyLongArrType_Type) {
+    out_d = dynd::ndt::make_type<npy_long>();
+  }
+  else if (obj == &PyULongArrType_Type) {
+    out_d = dynd::ndt::make_type<npy_ulong>();
+  }
+  else if (obj == &PyLongLongArrType_Type) {
+    out_d = dynd::ndt::make_type<npy_longlong>();
+  }
+  else if (obj == &PyULongLongArrType_Type) {
+    out_d = dynd::ndt::make_type<npy_ulonglong>();
+  }
+  else if (obj == &PyFloatArrType_Type) {
+    out_d = dynd::ndt::make_type<npy_float>();
+  }
+  else if (obj == &PyDoubleArrType_Type) {
+    out_d = dynd::ndt::make_type<npy_double>();
+  }
+  else if (obj == &PyCFloatArrType_Type) {
+    out_d = dynd::ndt::make_type<dynd::complex<float>>();
+  }
+  else if (obj == &PyCDoubleArrType_Type) {
+    out_d = dynd::ndt::make_type<dynd::complex<double>>();
+  }
+  else {
+    return -1;
+  }
+
+  return 0;
+}
+
+dynd::ndt::type pydynd::_type_of_numpy_scalar(PyObject *obj)
+{
+  if (PyArray_IsScalar(obj, Bool)) {
+    return dynd::ndt::make_type<dynd::bool1>();
+  }
+  else if (PyArray_IsScalar(obj, Byte)) {
+    return dynd::ndt::make_type<npy_byte>();
+  }
+  else if (PyArray_IsScalar(obj, UByte)) {
+    return dynd::ndt::make_type<npy_ubyte>();
+  }
+  else if (PyArray_IsScalar(obj, Short)) {
+    return dynd::ndt::make_type<npy_short>();
+  }
+  else if (PyArray_IsScalar(obj, UShort)) {
+    return dynd::ndt::make_type<npy_ushort>();
+  }
+  else if (PyArray_IsScalar(obj, Int)) {
+    return dynd::ndt::make_type<npy_int>();
+  }
+  else if (PyArray_IsScalar(obj, UInt)) {
+    return dynd::ndt::make_type<npy_uint>();
+  }
+  else if (PyArray_IsScalar(obj, Long)) {
+    return dynd::ndt::make_type<npy_long>();
+  }
+  else if (PyArray_IsScalar(obj, ULong)) {
+    return dynd::ndt::make_type<npy_ulong>();
+  }
+  else if (PyArray_IsScalar(obj, LongLong)) {
+    return dynd::ndt::make_type<npy_longlong>();
+  }
+  else if (PyArray_IsScalar(obj, ULongLong)) {
+    return dynd::ndt::make_type<npy_ulonglong>();
+  }
+  else if (PyArray_IsScalar(obj, Float)) {
+    return dynd::ndt::make_type<float>();
+  }
+  else if (PyArray_IsScalar(obj, Double)) {
+    return dynd::ndt::make_type<double>();
+  }
+  else if (PyArray_IsScalar(obj, CFloat)) {
+    return dynd::ndt::make_type<dynd::complex<float>>();
+  }
+  else if (PyArray_IsScalar(obj, CDouble)) {
+    return dynd::ndt::make_type<dynd::complex<double>>();
+  }
+
+  throw dynd::type_error("could not deduce a pydynd type from the numpy scalar object");
+}
+
+dynd::ndt::type pydynd::array_from_numpy_array2(PyArrayObject *obj)
+{
+  PyArray_Descr *dtype = PyArray_DESCR(obj);
+
+  if (PyDataType_FLAGCHK(dtype, NPY_ITEM_HASOBJECT)) {
+    return dynd::ndt::make_fixed_dim(PyArray_NDIM(obj), PyArray_SHAPE(obj),
+                                     pydynd::_type_from_numpy_dtype(dtype).get_canonical_type());
+  }
+  else {
+    // Get the dtype of the array
+    dynd::ndt::type d = pydynd::_type_from_numpy_dtype(PyArray_DESCR(obj), get_alignment_of(obj));
+    return dynd::ndt::make_fixed_dim(PyArray_NDIM(obj), PyArray_DIMS(obj), d);
+  }
+}
+
+dynd::ndt::type pydynd::array_from_numpy_scalar2(PyObject *obj)
+{
+  if (PyArray_IsScalar(obj, Bool)) {
+    return dynd::ndt::make_type<bool>();
+  }
+
+  if (PyArray_IsScalar(obj, Byte)) {
+    return dynd::ndt::make_type<signed char>();
+  }
+
+  if (PyArray_IsScalar(obj, UByte)) {
+    return dynd::ndt::make_type<unsigned char>();
+  }
+
+  if (PyArray_IsScalar(obj, Short)) {
+    return dynd::ndt::make_type<short>();
+  }
+
+  if (PyArray_IsScalar(obj, UShort)) {
+    return dynd::ndt::make_type<unsigned short>();
+  }
+
+  if (PyArray_IsScalar(obj, Int)) {
+    return dynd::ndt::make_type<int>();
+  }
+
+  if (PyArray_IsScalar(obj, UInt)) {
+    return dynd::ndt::make_type<unsigned int>();
+  }
+
+  if (PyArray_IsScalar(obj, Long)) {
+    return dynd::ndt::make_type<long>();
+  }
+
+  if (PyArray_IsScalar(obj, ULong)) {
+    return dynd::ndt::make_type<unsigned long>();
+  }
+
+  if (PyArray_IsScalar(obj, LongLong)) {
+    return dynd::ndt::make_type<long long>();
+  }
+
+  if (PyArray_IsScalar(obj, ULongLong)) {
+    return dynd::ndt::make_type<unsigned long long>();
+  }
+
+  if (PyArray_IsScalar(obj, Float)) {
+    return dynd::ndt::make_type<float>();
+  }
+
+  if (PyArray_IsScalar(obj, Double)) {
+    return dynd::ndt::make_type<double>();
+  }
+
+  if (PyArray_IsScalar(obj, CFloat)) {
+    return dynd::ndt::make_type<dynd::complex<float>>();
+  }
+
+  if (PyArray_IsScalar(obj, CDouble)) {
+    return dynd::ndt::make_type<dynd::complex<double>>();
+  }
+
+  if (PyArray_IsScalar(obj, Void)) {
+    return dynd::ndt::make_type<void>();
+  }
+
+  stringstream ss;
+  pyobject_ownref obj_tp(PyObject_Repr((PyObject *)Py_TYPE(obj)));
+  ss << "could not create a dynd array from the numpy scalar object";
+  ss << " of type " << pydynd::pystring_as_string(obj_tp.get());
+  throw dynd::type_error(ss.str());
+}
+
+bool pydynd::is_numpy_dtype(PyObject *o) { return PyArray_DescrCheck(o); }
+
+#endif


### PR DESCRIPTION
This breaks up some of the numpy interop code so that the type module doesn't have any cython-level dependencies on the array module.

The type module still has to use array_conversions.cpp to provide the check for whether or not something is an array in the type deduction code. That'll have to be replaced by some sort of dynamic machinery as well.