### PR TITLE
Stop linking type modules against libdynd

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,7 +241,41 @@ postprocess_cython( postprocess.py dynd.ndt.type_postprocess dynd.ndt.type_pyx d
 postprocess_cython( postprocess.py dynd.nd.array_postprocess dynd.nd.array_pyx dynd.nd.array)
 postprocess_cython( postprocess.py dynd.nd.callable_postprocess dynd.nd.callable_pyx dynd.nd.callable)
 
-foreach(module dynd.config dynd.ndt.type dynd.ndt.json dynd.nd.array dynd.nd.callable dynd.nd.functional dynd.nd.registry)
+# Linker commands for the dynd.ndt module.
+foreach(module dynd.ndt.type dynd.ndt.json)
+    # Temporarily continue to define PYDYND_EXPORT to avoid inconsistent linkage warnings.
+    # This should be removed once the macros have been refactored to hide all symbols
+    # other than module initialization routines.
+    set_property(
+        TARGET ${module}
+        PROPERTY COMPILE_DEFINITIONS PYDYND_EXPORT
+    )
+    if(DYND_INSTALL_LIB)
+        target_link_libraries(${module} "${LIBNDT_LIBRARY}")
+    else()
+        target_link_libraries(${module} libdyndt)
+        if(UNIX)
+            # Make sure libdyndt is on the rpath.
+            # On Windows, the dll is loaded dynamically via the logic in
+            # dynd/__init__.py
+            if(APPLE)
+                set(module_install_rpath "@loader_path")
+            else()
+                set(module_install_rpath "$ORIGIN")
+            endif()
+            string(REPLACE "." ";" module_directories "${module}")
+            list(LENGTH module_directories i)
+            while(${i} GREATER 2)
+                set(module_install_rpath "${module_install_rpath}/..")
+                math(EXPR i "${i} - 1" )
+            endwhile(${i} GREATER 2)
+            set_target_properties(${module} PROPERTIES INSTALL_RPATH ${module_install_rpath})
+        endif()
+    endif()
+endforeach(module)
+
+# Linker commands for the dynd.nd module.
+foreach(module dynd.config dynd.nd.array dynd.nd.callable dynd.nd.functional dynd.nd.registry)
     # Temporarily continue to define PYDYND_EXPORT to avoid inconsistent linkage warnings.
     # This should be removed once the macros have been refactored to hide all symbols
     # other than module initialization routines.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -251,7 +251,7 @@ foreach(module dynd.ndt.type dynd.ndt.json)
         PROPERTY COMPILE_DEFINITIONS PYDYND_EXPORT
     )
     if(DYND_INSTALL_LIB)
-        target_link_libraries(${module} "${LIBNDT_LIBRARY}")
+        target_link_libraries(${module} "${LIBDYNDT_LIBRARY}")
     else()
         target_link_libraries(${module} libdyndt)
         if(UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -218,12 +218,15 @@ cython_add_module(dynd.ndt.type dynd.ndt.type_pyx True
                   dynd/src/type_deduction.cpp
                   )
 
-foreach(module dynd.ndt.json dynd.nd.callable dynd.nd.functional dynd.nd.registry)
+cython_add_module(dynd.ndt.json dynd.ndt.json_pyx True dynd/src/type_conversions.cpp)
+
+foreach(module dynd.nd.callable dynd.nd.functional dynd.nd.registry)
     cython_add_module(${module} ${module}_pyx True
                       # Additional C++ source files:
                       dynd/src/type_conversions.cpp
                       dynd/src/array_conversions.cpp)
 endforeach(module)
+
 if (DYND_PYTHON_INPLACE_BUILD)
     set_target_library_output_dir(dynd.config "${PROJECT_SOURCE_DIR}/dynd")
     set_target_library_output_dir(dynd.nd.array "${PROJECT_SOURCE_DIR}/dynd/nd")

--- a/cmake/FindLibDyND.cmake
+++ b/cmake/FindLibDyND.cmake
@@ -59,6 +59,16 @@ if("${_LIBDYND_CONFIG}" STREQUAL "")
 
 else()
 
+    # Get the ndt library to link against.
+    execute_process(COMMAND "${_LIBDYND_CONFIG}" "-libndtname"
+                    RESULT_VARIABLE _DYND_SEARCH_SUCCESS
+                    OUTPUT_VARIABLE LIBNDT_NAME
+                    ERROR_VARIABLE _DYND_ERROR_VALUE
+                    OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if(NOT _DYND_SEARCH_SUCCESS MATCHES 0)
+        message(FATAL_ERROR "Error getting ndt library name:\n${_DYND_ERROR_VALUE}")
+    endif()
+
     # Get the libraries to link against.
     execute_process(COMMAND "${_LIBDYND_CONFIG}" "-libnames"
                     RESULT_VARIABLE _DYND_SEARCH_SUCCESS
@@ -82,6 +92,9 @@ else()
     if(WIN32)
         string(REPLACE "\\" "/" LIBDYND_LIBRARY_DIR ${LIBDYND_LIBRARY_DIR})
     endif()
+
+    set(LIBNDT_LIBRARY "${LIBDYND_LIBRARY_DIR}/${LIBNDT_NAME}")
+
     set(LIBDYND_LIBRARIES "")
     foreach(_lib ${LIBDYND_LIBRARY_NAMES})
         LIST(APPEND LIBDYND_LIBRARIES "${LIBDYND_LIBRARY_DIR}/${_lib}")

--- a/cmake/FindLibDyND.cmake
+++ b/cmake/FindLibDyND.cmake
@@ -60,9 +60,9 @@ if("${_LIBDYND_CONFIG}" STREQUAL "")
 else()
 
     # Get the ndt library to link against.
-    execute_process(COMMAND "${_LIBDYND_CONFIG}" "-libndtname"
+    execute_process(COMMAND "${_LIBDYND_CONFIG}" "-libdyndtname"
                     RESULT_VARIABLE _DYND_SEARCH_SUCCESS
-                    OUTPUT_VARIABLE LIBNDT_NAME
+                    OUTPUT_VARIABLE LIBDYNDT_NAME
                     ERROR_VARIABLE _DYND_ERROR_VALUE
                     OUTPUT_STRIP_TRAILING_WHITESPACE)
     if(NOT _DYND_SEARCH_SUCCESS MATCHES 0)
@@ -93,7 +93,7 @@ else()
         string(REPLACE "\\" "/" LIBDYND_LIBRARY_DIR ${LIBDYND_LIBRARY_DIR})
     endif()
 
-    set(LIBNDT_LIBRARY "${LIBDYND_LIBRARY_DIR}/${LIBNDT_NAME}")
+    set(LIBDYNDT_LIBRARY "${LIBDYND_LIBRARY_DIR}/${LIBDYNDT_NAME}")
 
     set(LIBDYND_LIBRARIES "")
     foreach(_lib ${LIBDYND_LIBRARY_NAMES})


### PR DESCRIPTION
Slight cleanup of https://github.com/libdynd/dynd-python/pull/689.