### PR TITLE
Refactor test discovery and add support for "python -m dynd.ndt.test".

### DIFF
--- a/dynd/__init__.py
+++ b/dynd/__init__.py
@@ -118,6 +118,7 @@ def test(verbosity=1, xunitfile=None, exit=False):
     print('LibDyND git sha1: %s' % __libdynd_git_sha1__)
     print('NumPy version: %s' % numpy.__version__)
     sys.stdout.flush()
+
     if xunitfile is None:
         s1 = dynd.ndt.test.discover()
         s2 = dynd.nd.test.discover()

--- a/dynd/__init__.py
+++ b/dynd/__init__.py
@@ -104,9 +104,9 @@ def test(verbosity=1, xunitfile=None, exit=False):
     """
     import os, sys, subprocess
     import numpy
-    from .ndt.test import get_tst_module as ndt_test
-    from .nd.test import get_tst_module as nd_test
     import unittest
+    import dynd.ndt.test
+    import dynd.nd.test
 
     print('Running unit tests for the DyND Python bindings')
     print('Python version: %s' % sys.version)
@@ -119,18 +119,10 @@ def test(verbosity=1, xunitfile=None, exit=False):
     print('NumPy version: %s' % numpy.__version__)
     sys.stdout.flush()
     if xunitfile is None:
-        # Run all the tests
-        all_suites = []
-        for fn in os.listdir(os.path.join(os.path.dirname(__file__), 'ndt/test')):
-            if fn.startswith('test_') and fn.endswith('.py'):
-                tst = ndt_test(fn[:-3])
-                all_suites.append(unittest.defaultTestLoader.loadTestsFromModule(tst))
-        for fn in os.listdir(os.path.join(os.path.dirname(__file__), 'nd/test')):
-            if fn.startswith('test_') and fn.endswith('.py'):
-                tst = nd_test(fn[:-3])
-                all_suites.append(unittest.defaultTestLoader.loadTestsFromModule(tst))
+        s1 = dynd.ndt.test.discover()
+        s2 = dynd.nd.test.discover()
         runner = unittest.TextTestRunner(stream=sys.stdout, verbosity=verbosity)
-        result = runner.run(unittest.TestSuite(all_suites))
+        result = runner.run(unittest.TestSuite(s1 + s2))
         if exit:
             sys.exit(not result.wasSuccessful())
         else:

--- a/dynd/nd/test/__init__.py
+++ b/dynd/nd/test/__init__.py
@@ -1,4 +1,18 @@
-def get_tst_module(m):
-    l = dict(locals())
-    exec('from . import %s as tst' % m, globals(), l)
-    return l['tst']
+import os, sys
+import unittest
+import importlib
+
+def discover():
+    all_suites = []
+    for f in os.listdir(os.path.dirname(__file__)):
+        if f.startswith('test') and f.endswith('.py'):
+            name = '.' + os.path.splitext(f)[0]
+            m = importlib.import_module(name, package=__name__)
+            suite = unittest.defaultTestLoader.loadTestsFromModule(m)
+            all_suites.append(suite)
+    return all_suites
+
+def run(stream=sys.stderr, verbosity=2):
+    all_suites = discover()
+    runner = unittest.TextTestRunner(stream=stream, verbosity=verbosity)
+    return runner.run(unittest.TestSuite(all_suites))

--- a/dynd/nd/test/__main__.py
+++ b/dynd/nd/test/__main__.py
@@ -1,0 +1,4 @@
+import sys
+from . import run
+result = run()
+sys.exit(not result.wasSuccessful())

--- a/dynd/ndt/test/__init__.py
+++ b/dynd/ndt/test/__init__.py
@@ -1,4 +1,18 @@
-def get_tst_module(m):
-    l = dict(locals())
-    exec('from . import %s as tst' % m, globals(), l)
-    return l['tst']
+import os, sys
+import unittest
+import importlib
+
+def discover():
+    all_suites = []
+    for f in os.listdir(os.path.dirname(__file__)):
+        if f.startswith('test') and f.endswith('.py'):
+            name = '.' + os.path.splitext(f)[0]
+            m = importlib.import_module(name, package=__name__)
+            suite = unittest.defaultTestLoader.loadTestsFromModule(m)
+            all_suites.append(suite)
+    return all_suites
+
+def run(stream=sys.stderr, verbosity=2):
+    all_suites = discover()
+    runner = unittest.TextTestRunner(stream=stream, verbosity=verbosity)
+    return runner.run(unittest.TestSuite(all_suites))

--- a/dynd/ndt/test/__main__.py
+++ b/dynd/ndt/test/__main__.py
@@ -1,0 +1,4 @@
+import sys
+from . import run
+result = run()
+sys.exit(not result.wasSuccessful())


### PR DESCRIPTION
This adds support for runnings the tests as ```python -m dynd.ndt.test``` and ```python -m dynd.nd.test```.