### PR TITLE
Namespace package

### DIFF
--- a/dynd/__init__.py
+++ b/dynd/__init__.py
@@ -118,6 +118,7 @@ def test(verbosity=1, xunitfile=None, exit=False):
     print('LibDyND git sha1: %s' % __libdynd_git_sha1__)
     print('NumPy version: %s' % numpy.__version__)
     sys.stdout.flush()
+
     if xunitfile is None:
         s1 = dynd.ndt.test.discover()
         s2 = dynd.nd.test.discover()

--- a/dynd/__init__.py
+++ b/dynd/__init__.py
@@ -1,148 +1,29 @@
-import os
-if os.name == 'nt':
-    # Manually load dlls before loading the extension modules.
-    # This is handled via rpaths on Unix based systems.
-    import ctypes
-    import os.path
-    def load_dynd_dll(rootpath):
-        try:
-            ctypes.cdll.LoadLibrary(os.path.join(rootpath, 'libdyndt.dll'))
-            ctypes.cdll.LoadLibrary(os.path.join(rootpath, 'libdynd.dll'))
-            return True;
-        except OSError:
-            return False;
-    # If libdynd.dll has been placed in the dynd-python installation, use that
-    loaded = load_dynd_dll(os.path.dirname(__file__))
-    # Next, try the default DLL search path
-    loaded = loaded or load_dynd_dll('')
-    if not loaded:
-        # Try to load it from the Program Files directories where libdynd
-        # installs by default. This matches the search path for libdynd used
-        # in the CMake build for dynd-python.
-        import sys
-        is_64_bit = sys.maxsize > 2**32
-        processor_arch = os.environ.get('PROCESSOR_ARCHITECTURE')
-        err_str = ('Fallback search for libdynd.dll failed because the "{}" '
-                   'environment variable was not set. Please make sure that '
-                   'either libdynd is on the DLL search path or that it is '
-                   'in the default install directory and the runtime '
-                   'environment has the necessary system-specified '
-                   'environment variables properly set. On 64 bit Windows '
-                   'with 64 bit Python the needed variables are '
-                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles". On 64 bit '
-                   'Windows with 32 bit Python the needed variables are '
-                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles(x86)". On 32 '
-                   'bit Windows the needed variables are '
-                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles".')
-        if processor_arch is None:
-            raise RuntimeError(err_str.format('PROCESSOR_ARCHITECTURE'))
-        is_32_on_64_bit = (is_64_bit and not processor_arch.endswith('64'))
-        if not is_32_on_64_bit:
-            prog_files = os.environ.get('ProgramFiles')
-            if prog_files is None:
-                raise RuntimeError(err_str.format('ProgramFiles'))
-        else:
-            prog_files = os.environ.get('ProgramFiles(x86)')
-            if prog_files is None:
-                raise RuntimeError(err_str.format('ProgramFiles(x86)'))
-        dynd_lib_dir = os.path.join(prog_files, 'libdynd', 'lib')
-        if os.path.isdir(dynd_lib_dir):
-            loaded = load_dynd_dll(dynd_lib_dir)
-            if not loaded:
-                raise ctypes.WinError(126, 'Could not load libdynd.dll '
-                                           'or libdyndt.dll')
+# DyND is a namespace package with the components dynd.ndt and dynd.nd.
+try:
+    import pkg_resources
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    import pkgutil
+    __path__ = pkgutil.extend_path(__path__, __name__)
 
-from .config import _dynd_version_string as __libdynd_version__, \
-                _dynd_python_version_string as __version__, \
-                _dynd_git_sha1 as __libdynd_git_sha1__, \
-                _dynd_python_git_sha1 as __git_sha1__
+try:
+    from .common import *
+except:
+    pass
 
-def annotate(*args, **kwds):
-    def wrap(func):
-        func.__annotations__ = {}
+__all__ = [
+    '__libdynd_version__', '__version__', '__libdynd_git_sha1__', ' __git_sha1__',
+    'annotate', 'test', 'load'
+]
 
-        try:
-            func.__annotations__['return'] = args[0]
-        except IndexError:
-            pass
 
-        if len(args[1:]) > func.__code__.co_argcount:
-            raise TypeError('{0} takes {1} positional arguments but {2} positional annotations were given'.format(func,
-                func.__code__.co_argcount, len(args) - 1))
+try: del common
+except: pass
 
-        for key, value in zip(func.__code__.co_varnames, args[1:]):
-            func.__annotations__[key] = value
+try: del pkgutil
+except: pass
 
-        for key, value in kwds.items():
-            if key not in func.__code__.co_varnames:
-                raise TypeError("{0} got an unexpected keyword annotation '{1}'".format(func, key))
-            if key in func.__annotations__:
-                raise TypeError("{0} got multiple values for annotation '{1}'".format(func, key))
+try: del pkg_resources
+except: pass
 
-            func.__annotations__[key] = value
 
-        return func
-
-    return wrap
-
-def test(verbosity=1, xunitfile=None, exit=False):
-    """
-    Runs the full DyND test suite, outputing
-    the results of the tests to  sys.stdout.
-    Parameters
-    ----------
-    verbosity : int, optional
-        Value 0 prints very little, 1 prints a little bit,
-        and 2 prints the test names while testing.
-    xunitfile : string, optional
-        If provided, writes the test results to an xunit
-        style xml file. This is useful for running the tests
-        in a CI server such as Jenkins.
-    exit : bool, optional
-        If True, the function will call sys.exit with an
-        error code after the tests are finished.
-    """
-    import os, sys, subprocess
-    import numpy
-    import unittest
-    import dynd.ndt.test
-    import dynd.nd.test
-
-    print('Running unit tests for the DyND Python bindings')
-    print('Python version: %s' % sys.version)
-    print('Python prefix: %s' % sys.prefix)
-    print('DyND-Python module: %s' % os.path.dirname(__file__))
-    print('DyND-Python version: %s' % __version__)
-    print('DyND-Python git sha1: %s' % __git_sha1__)
-    print('LibDyND version: %s' % __libdynd_version__)
-    print('LibDyND git sha1: %s' % __libdynd_git_sha1__)
-    print('NumPy version: %s' % numpy.__version__)
-    sys.stdout.flush()
-
-    if xunitfile is None:
-        s1 = dynd.ndt.test.discover()
-        s2 = dynd.nd.test.discover()
-        runner = unittest.TextTestRunner(stream=sys.stdout, verbosity=verbosity)
-        result = runner.run(unittest.TestSuite(s1 + s2))
-        if exit:
-            sys.exit(not result.wasSuccessful())
-        else:
-            return result
-    else:
-        import nose
-        import os
-        argv = ['nosetests', '--verbosity=%d' % verbosity]
-        # Output an xunit file if requested
-        if xunitfile:
-            argv.extend(['--with-xunit', '--xunit-file=%s' % xunitfile])
-        # Add all 'tests' subdirectories to the options
-        rootdir = os.path.dirname(__file__)
-        for root, dirs, files in os.walk(rootdir):
-            if 'test' in dirs:
-                testsdir = os.path.join(root, 'test')
-                argv.append(testsdir)
-                print('Test dir: %s' % testsdir[len(rootdir)+1:])
-        # Ask nose to do its thing
-        return nose.main(argv=argv, exit=exit)
-
-from .config import load

--- a/dynd/__init__.py
+++ b/dynd/__init__.py
@@ -6,9 +6,9 @@ except ImportError:
     import pkgutil
     __path__ = pkgutil.extend_path(__path__, __name__)
 
-try:
+try: # Only the import from dynd.ndt is expected to succeed.
     from .common import *
-except:
+except ImportError:
     pass
 
 __all__ = [

--- a/dynd/__init__.py
+++ b/dynd/__init__.py
@@ -104,9 +104,9 @@ def test(verbosity=1, xunitfile=None, exit=False):
     """
     import os, sys, subprocess
     import numpy
-    from .ndt.test import get_tst_module as ndt_test
-    from .nd.test import get_tst_module as nd_test
     import unittest
+    import dynd.ndt.test
+    import dynd.nd.test
 
     print('Running unit tests for the DyND Python bindings')
     print('Python version: %s' % sys.version)
@@ -119,18 +119,10 @@ def test(verbosity=1, xunitfile=None, exit=False):
     print('NumPy version: %s' % numpy.__version__)
     sys.stdout.flush()
     if xunitfile is None:
-        # Run all the tests
-        all_suites = []
-        for fn in os.listdir(os.path.join(os.path.dirname(__file__), 'ndt/test')):
-            if fn.startswith('test_') and fn.endswith('.py'):
-                tst = ndt_test(fn[:-3])
-                all_suites.append(unittest.defaultTestLoader.loadTestsFromModule(tst))
-        for fn in os.listdir(os.path.join(os.path.dirname(__file__), 'nd/test')):
-            if fn.startswith('test_') and fn.endswith('.py'):
-                tst = nd_test(fn[:-3])
-                all_suites.append(unittest.defaultTestLoader.loadTestsFromModule(tst))
+        s1 = dynd.ndt.test.discover()
+        s2 = dynd.nd.test.discover()
         runner = unittest.TextTestRunner(stream=sys.stdout, verbosity=verbosity)
-        result = runner.run(unittest.TestSuite(all_suites))
+        result = runner.run(unittest.TestSuite(s1 + s2))
         if exit:
             sys.exit(not result.wasSuccessful())
         else:

--- a/dynd/common/__init__.py
+++ b/dynd/common/__init__.py
@@ -1,0 +1,101 @@
+from ..config import _dynd_version_string as __libdynd_version__, \
+                     _dynd_python_version_string as __version__, \
+                     _dynd_git_sha1 as __libdynd_git_sha1__, \
+                     _dynd_python_git_sha1 as __git_sha1__, \
+                     load
+
+__all__ = [
+    '__libdynd_version__', '__version__', '__libdynd_git_sha1__', '__git_sha1__',
+    'annotate', 'test', 'load'
+]
+
+def annotate(*args, **kwds):
+    def wrap(func):
+        func.__annotations__ = {}
+
+        try:
+            func.__annotations__['return'] = args[0]
+        except IndexError:
+            pass
+
+        if len(args[1:]) > func.__code__.co_argcount:
+            raise TypeError('{0} takes {1} positional arguments but {2} positional annotations were given'.format(func,
+                func.__code__.co_argcount, len(args) - 1))
+
+        for key, value in zip(func.__code__.co_varnames, args[1:]):
+            func.__annotations__[key] = value
+
+        for key, value in kwds.items():
+            if key not in func.__code__.co_varnames:
+                raise TypeError("{0} got an unexpected keyword annotation '{1}'".format(func, key))
+            if key in func.__annotations__:
+                raise TypeError("{0} got multiple values for annotation '{1}'".format(func, key))
+
+            func.__annotations__[key] = value
+
+        return func
+
+    return wrap
+
+def test(verbosity=1, xunitfile=None, exit=False):
+    """
+    Runs the full DyND test suite, outputing
+    the results of the tests to  sys.stdout.
+    Parameters
+    ----------
+    verbosity : int, optional
+        Value 0 prints very little, 1 prints a little bit,
+        and 2 prints the test names while testing.
+    xunitfile : string, optional
+        If provided, writes the test results to an xunit
+        style xml file. This is useful for running the tests
+        in a CI server such as Jenkins.
+    exit : bool, optional
+        If True, the function will call sys.exit with an
+        error code after the tests are finished.
+    """
+    import os, sys, subprocess
+    import numpy
+    import unittest
+    import dynd.ndt.test as ndt_test
+    try:
+        import dynd.nd.test as nd_test
+    except ImportError:
+        nd_test = None
+
+    print('Running unit tests for the DyND Python bindings')
+    print('Python version: %s' % sys.version)
+    print('Python prefix: %s' % sys.prefix)
+    print('DyND-Python module: %s' % os.path.dirname(__file__))
+    print('DyND-Python version: %s' % __version__)
+    print('DyND-Python git sha1: %s' % __git_sha1__)
+    print('LibDyND version: %s' % __libdynd_version__)
+    print('LibDyND git sha1: %s' % __libdynd_git_sha1__)
+    print('NumPy version: %s' % numpy.__version__)
+    sys.stdout.flush()
+
+    if xunitfile is None:
+        s1 = ndt_test.discover()
+        s2 = nd_test.discover() if nd_test else []
+        runner = unittest.TextTestRunner(stream=sys.stdout, verbosity=verbosity)
+        result = runner.run(unittest.TestSuite(s1 + s2))
+        if exit:
+            sys.exit(not result.wasSuccessful())
+        else:
+            return result
+    else:
+        import nose
+        import os
+        argv = ['nosetests', '--verbosity=%d' % verbosity]
+        # Output an xunit file if requested
+        if xunitfile:
+            argv.extend(['--with-xunit', '--xunit-file=%s' % xunitfile])
+        # Add all 'tests' subdirectories to the options
+        rootdir = os.path.dirname(__file__)
+        for root, dirs, files in os.walk(rootdir):
+            if 'test' in dirs:
+                testsdir = os.path.join(root, 'test')
+                argv.append(testsdir)
+                print('Test dir: %s' % testsdir[len(rootdir)+1:])
+        # Ask nose to do its thing
+        return nose.main(argv=argv, exit=exit)

--- a/dynd/common/__init__.py
+++ b/dynd/common/__init__.py
@@ -66,7 +66,7 @@ def test(verbosity=1, xunitfile=None, exit=False):
     print('Running unit tests for the DyND Python bindings')
     print('Python version: %s' % sys.version)
     print('Python prefix: %s' % sys.prefix)
-    print('DyND-Python module: %s' % os.path.dirname(__file__))
+    print('DyND-Python module: %s' % os.path.dirname(os.path.dirname(__file__)))
     print('DyND-Python version: %s' % __version__)
     print('DyND-Python git sha1: %s' % __git_sha1__)
     print('LibDyND version: %s' % __libdynd_version__)

--- a/dynd/nd/__init__.py
+++ b/dynd/nd/__init__.py
@@ -1,4 +1,4 @@
-import dynd.ndt
+from .. import ndt # ensure that the module is loaded first
 import sys
 import os
 
@@ -77,4 +77,4 @@ publish_callables(sys.modules[__name__])
 
 del os
 del sys
-del dynd.ndt
+del ndt

--- a/dynd/nd/__init__.py
+++ b/dynd/nd/__init__.py
@@ -1,5 +1,63 @@
 import sys
 
+import os
+if os.name == 'nt':
+    # Manually load dlls before loading the extension modules.
+    # This is handled via rpaths on Unix based systems.
+    import ctypes
+    import os.path
+    import dynd.ndt
+    ndtdir = os.path.join(os.path.dirname(os.path.abspath(dynd.ndt.__file__)), '..')
+    nddir = os.path.join(os.path.dirname(__file__), '..')
+    def load_dynd_dll(ndtdir=ndtdir, nddir=nddir):
+        try:
+            ctypes.cdll.LoadLibrary(os.path.join(ndtdir, 'libdyndt.dll'))
+            ctypes.cdll.LoadLibrary(os.path.join(nddir, 'libdynd.dll'))
+            return True
+        except OSError:
+            return False
+    # If libdynd.dll has been placed in the dynd-python installation, use that
+    loaded = load_dynd_dll()
+    # Next, try the default DLL search path
+    loaded = loaded or load_dynd_dll(ndtdir='', nddir='')
+    if not loaded:
+        # Try to load it from the Program Files directories where libdynd
+        # installs by default. This matches the search path for libdynd used
+        # in the CMake build for dynd-python.
+        import sys
+        is_64_bit = sys.maxsize > 2**32
+        processor_arch = os.environ.get('PROCESSOR_ARCHITECTURE')
+        err_str = ('Fallback search for libdynd.dll failed because the "{}" '
+                   'environment variable was not set. Please make sure that '
+                   'either libdynd is on the DLL search path or that it is '
+                   'in the default install directory and the runtime '
+                   'environment has the necessary system-specified '
+                   'environment variables properly set. On 64 bit Windows '
+                   'with 64 bit Python the needed variables are '
+                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles". On 64 bit '
+                   'Windows with 32 bit Python the needed variables are '
+                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles(x86)". On 32 '
+                   'bit Windows the needed variables are '
+                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles".')
+        if processor_arch is None:
+            raise RuntimeError(err_str.format('PROCESSOR_ARCHITECTURE'))
+        is_32_on_64_bit = (is_64_bit and not processor_arch.endswith('64'))
+        if not is_32_on_64_bit:
+            prog_files = os.environ.get('ProgramFiles')
+            if prog_files is None:
+                raise RuntimeError(err_str.format('ProgramFiles'))
+        else:
+            prog_files = os.environ.get('ProgramFiles(x86)')
+            if prog_files is None:
+                raise RuntimeError(err_str.format('ProgramFiles(x86)'))
+        dynd_lib_dir = os.path.join(prog_files, 'libdynd', 'lib')
+        if os.path.isdir(dynd_lib_dir):
+            loaded = load_dynd_dll(ndtdir=dynd_lib_dir, nddir=dynd_lib_dir)
+            if not loaded:
+                raise ctypes.WinError(126, 'Could not load libdynd.dll '
+                                           'or libdyndt.dll')
+
+
 from dynd.config import *
 
 from .array import array, asarray, type_of, dshape_of, as_py, view, \

--- a/dynd/nd/test/__init__.py
+++ b/dynd/nd/test/__init__.py
@@ -1,4 +1,18 @@
-def get_tst_module(m):
-    l = dict(locals())
-    exec('from . import %s as tst' % m, globals(), l)
-    return l['tst']
+import os, sys
+import unittest
+import importlib
+
+def discover():
+    all_suites = []
+    for f in os.listdir(os.path.dirname(__file__)):
+        if f.startswith('test') and f.endswith('.py'):
+            name = '.' + os.path.splitext(f)[0]
+            m = importlib.import_module(name, package=__name__)
+            suite = unittest.defaultTestLoader.loadTestsFromModule(m)
+            all_suites.append(suite)
+    return all_suites
+
+def run(stream=sys.stderr, verbosity=2):
+    all_suites = discover()
+    runner = unittest.TextTestRunner(stream=stream, verbosity=verbosity)
+    return runner.run(unittest.TestSuite(all_suites))

--- a/dynd/nd/test/__main__.py
+++ b/dynd/nd/test/__main__.py
@@ -1,0 +1,4 @@
+import sys
+from . import run
+result = run()
+sys.exit(not result.wasSuccessful())

--- a/dynd/ndt/__init__.py
+++ b/dynd/ndt/__init__.py
@@ -1,3 +1,57 @@
+import os
+if os.name == 'nt':
+    # Manually load dlls before loading the extension modules.
+    # This is handled via rpaths on Unix based systems.
+    import ctypes
+    import os.path
+    import dynd.ndt
+    ndtdir = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..')
+    def load_dynd_dll(ndtdir=ndtdir):
+        try:
+            ctypes.cdll.LoadLibrary(os.path.join(ndtdir, 'libdyndt.dll'))
+            return True
+        except OSError:
+            return False
+    # If libdynd.dll has been placed in the dynd-python installation, use that
+    loaded = load_dynd_dll()
+    # Next, try the default DLL search path
+    loaded = loaded or load_dynd_dll(ndtdir='')
+    if not loaded:
+        # Try to load it from the Program Files directories where libdynd
+        # installs by default. This matches the search path for libdynd used
+        # in the CMake build for dynd-python.
+        import sys
+        is_64_bit = sys.maxsize > 2**32
+        processor_arch = os.environ.get('PROCESSOR_ARCHITECTURE')
+        err_str = ('Fallback search for libdyndt.dll failed because the "{}" '
+                   'environment variable was not set. Please make sure that '
+                   'either libdyndt is on the DLL search path or that it is '
+                   'in the default install directory and the runtime '
+                   'environment has the necessary system-specified '
+                   'environment variables properly set. On 64 bit Windows '
+                   'with 64 bit Python the needed variables are '
+                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles". On 64 bit '
+                   'Windows with 32 bit Python the needed variables are '
+                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles(x86)". On 32 '
+                   'bit Windows the needed variables are '
+                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles".')
+        if processor_arch is None:
+            raise RuntimeError(err_str.format('PROCESSOR_ARCHITECTURE'))
+        is_32_on_64_bit = (is_64_bit and not processor_arch.endswith('64'))
+        if not is_32_on_64_bit:
+            prog_files = os.environ.get('ProgramFiles')
+            if prog_files is None:
+                raise RuntimeError(err_str.format('ProgramFiles'))
+        else:
+            prog_files = os.environ.get('ProgramFiles(x86)')
+            if prog_files is None:
+                raise RuntimeError(err_str.format('ProgramFiles(x86)'))
+        dynd_lib_dir = os.path.join(prog_files, 'libdynd', 'lib')
+        if os.path.isdir(dynd_lib_dir):
+            loaded = load_dynd_dll(ndtdir=dynd_lib_dir)
+            if not loaded:
+                raise ctypes.WinError(126, 'Could not load libdyndt.dll')
+
 from .type import make_fixed_bytes, make_fixed_string, make_struct, \
     make_fixed_dim, make_string, make_var_dim, make_fixed_dim_kind, \
     type_for

--- a/dynd/ndt/test/__init__.py
+++ b/dynd/ndt/test/__init__.py
@@ -1,4 +1,18 @@
-def get_tst_module(m):
-    l = dict(locals())
-    exec('from . import %s as tst' % m, globals(), l)
-    return l['tst']
+import os, sys
+import unittest
+import importlib
+
+def discover():
+    all_suites = []
+    for f in os.listdir(os.path.dirname(__file__)):
+        if f.startswith('test') and f.endswith('.py'):
+            name = '.' + os.path.splitext(f)[0]
+            m = importlib.import_module(name, package=__name__)
+            suite = unittest.defaultTestLoader.loadTestsFromModule(m)
+            all_suites.append(suite)
+    return all_suites
+
+def run(stream=sys.stderr, verbosity=2):
+    all_suites = discover()
+    runner = unittest.TextTestRunner(stream=stream, verbosity=verbosity)
+    return runner.run(unittest.TestSuite(all_suites))

--- a/dynd/ndt/test/__main__.py
+++ b/dynd/ndt/test/__main__.py
@@ -1,0 +1,4 @@
+import sys
+from . import run
+result = run()
+sys.exit(not result.wasSuccessful())

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,27 @@ from subprocess import check_output
 
 import re
 
-# Distribution target: 'all', 'ndt', 'nd'
+#
+# DyND is a namespace package that contains the type module dynd.ndt and
+# the array/callables module dynd.nd. These are the supported install
+# methods together with the resulting directory hierarchies:
+#
+#   1) DIST_TARGET = 'all':
+#        dynd-x.y.z/dynd/ndt/*
+#        dynd-x.y.z/dynd/nd/*
+#
+#   2) DIST_TARGET = 'ndt':
+#        dynd.ndt-x.y.z/dynd/ndt/*
+#
+#   3) DIST_TARGET = 'nd':
+#        dynd.nd-x.y.z/dynd/nd/*
+#
+#      In this case also add dynd.ndt to requirements.txt.
+#
+# A single Python install should use either option 1) OR option 2) OR
+# option 2) followed by option 3).  All options require a clean build
+# directory. At the minimum build/, dist/ and dynd.egg* must be removed.
+#
 DIST_TARGET = 'all'
 class Target():
   def __init__(self, target):

--- a/setup.py
+++ b/setup.py
@@ -182,7 +182,7 @@ class cmake_build_ext(build_ext):
     if sys.platform != 'win32':
         cmake_command.append(source)
         self.spawn(cmake_command)
-        self.spawn(['make', '-j2'])
+        self.spawn(['make'])
     else:
         if "-G" not in self.extra_cmake_args:
             cmake_generator = 'Visual Studio 14 2015'


### PR DESCRIPTION
This (explicit) namespace package works here on Linux/Windows with both Python 2 and Python 3.

The magic switch is in setup.py:

     1) DIST_TARGET = 'all' -> The existing install.

     2) DIST_TARGET = 'ndt' -> Install only libdyndt and the ndt module.

     3) DIST_TARGET = 'nd' -> Install only libdynd and the nd module.


Options 1) and 2) are self-contained, 3) depends on 2).


