### PR TITLE
Remove calls to type constructors removed in libdynd

### DIFF
--- a/dynd/cpp/type.pxd
+++ b/dynd/cpp/type.pxd
@@ -36,3 +36,13 @@ cdef extern from 'dynd/type.hpp' namespace 'dynd::ndt' nogil:
         type_id_t get_base_id() const
 
     type make_type[T]() except +translate_exception
+
+    cppclass reg_info_t:
+        type tp
+
+# Ideally we wouldn't use the detail namespace, but this is currently
+# needed to map a type id back to the corresponding type.
+cdef extern from "<dynd/type.hpp>" nogil:
+    # Function doesn't really exist.
+    # Use this to avoid Cython's odd handling of lvalue references
+    reg_info_t _get_reg_info "dynd::ndt::detail::infos().operator[]"(type_id_t) except +translate_exception

--- a/dynd/include/array_conversions.hpp
+++ b/dynd/include/array_conversions.hpp
@@ -1,3 +1,23 @@
+//
+// Copyright (C) 2011-16 DyND Developers
+// BSD 2-Clause License, see LICENSE.txt
+//
+
+/* This file exists to expose whatever functionality from
+ * nd/array.pyx and nd/callable.pyx needs to be available
+ * in the C++ portions of the codebase.
+ * Currently it exists only as a means of
+ * exporting conversions between the Cython wrapper
+ * types and their corresponding C++ types.
+ * Those conversions must be exported from Cython
+ * to the C++ code since the ABI for the wrapper types
+ * must be defined there (and depends on Cython's ABI for
+ * extension types).
+ *
+ * The conversions defined here lazily load the modules
+ * that expose the core ABI for the wrapper types.
+*/
+
 #pragma once
 
 #include <Python.h>

--- a/dynd/include/type_conversions.hpp
+++ b/dynd/include/type_conversions.hpp
@@ -1,7 +1,22 @@
 //
-// Copyright (C) 2011-15 DyND Developers
+// Copyright (C) 2011-16 DyND Developers
 // BSD 2-Clause License, see LICENSE.txt
 //
+
+/* This file exists to expose whatever functionality from
+ * ndt/type.pyx needs to be available throughout the
+ * C++ codebase. Currently it exists only as a means
+ * of providing conversions between the Cython wrapper
+ * types and their corresponding C++ types.
+ * Those conversions must be exported from Cython
+ * to the C++ code since the ABI for the wrapper types
+ * must be defined there (and depends on Cython's ABI for
+ * extension types).
+ *
+ * The conversions defined here lazily load the modules
+ * that expose the core ABI for the wrapper types.
+*/
+
 #pragma once
 
 #include <Python.h>
@@ -17,6 +32,5 @@ PYDYND_API PyTypeObject *get_type_pytypeobject();
 PYDYND_API PyObject *type_from_cpp(const dynd::ndt::type &);
 PYDYND_API dynd::ndt::type dynd_ndt_as_cpp_type(PyObject *);
 PYDYND_API dynd::ndt::type dynd_ndt_cpp_type_for(PyObject *);
-PYDYND_API dynd::ndt::type ndt_type_from_pylist(PyObject *);
 
 } // namespace pydynd

--- a/dynd/include/type_deduction.hpp
+++ b/dynd/include/type_deduction.hpp
@@ -161,4 +161,6 @@ void register_nd_array_type_deduction(PyTypeObject *, dynd::ndt::type (*)(PyObje
 
 PYDYND_API dynd::ndt::type xtype_for_prefix(PyObject *obj);
 
+PYDYND_API dynd::ndt::type ndt_type_from_pylist(PyObject *);
+
 } // namespace pydynd

--- a/dynd/ndt/__init__.py
+++ b/dynd/ndt/__init__.py
@@ -57,16 +57,6 @@ from .type import make_fixed_bytes, make_fixed_string, make_struct, \
     type_for
 from .type import *
 
-intptr = type('intptr')
-uintptr = type('uintptr')
-# Aliases for people comfortable with the NumPy complex namings
-complex64 = complex_float32
-complex128 = complex_float64
-
-string = type('string')
-#json = type('json')
-bytes = type('bytes')
-
 # Some classes making dimension construction easier
 from .dim_helpers import *
 

--- a/dynd/ndt/type.pyx
+++ b/dynd/ndt/type.pyx
@@ -33,7 +33,7 @@ from ..cpp.types.callable_type cimport callable_type as _callable_type
 from ..cpp.types.string_type cimport string_type
 from ..cpp.types.bytes_type cimport bytes_type
 from ..cpp.types.fixed_bytes_type cimport fixed_bytes_type
-from ..cpp.type cimport make_type
+from ..cpp.type cimport make_type, _get_reg_info
 from ..cpp.complex cimport complex as dynd_complex
 
 from ..config cimport translate_exception
@@ -399,8 +399,6 @@ cdef _type as_cpp_type(object o) except *:
     elif _builtin_type(o) is str or PyUnicode_Check(<PyObject*>o):
         # Use Cython's automatic conversion to c++ strings.
         return _type(<string>o)
-    elif _builtin_type(o) is int or _builtin_type(o) is long:
-        return _type(<type_id_t>(<int>o))
     elif is_numpy_dtype(<PyObject*>o):
         return _type_from_numpy_dtype(<PyArray_Descr*>o)
     elif issubclass(o, _ctypes_base_type):
@@ -718,7 +716,8 @@ cdef as_numba_type(_type tp):
     return _to_numba_type[tp.get_id()]
 
 cdef _type from_numba_type(tp):
-    return _type(<type_id_t> _from_numba_type[tp])
+
+    return _get_reg_info((<type_id_t> _from_numba_type[tp])).tp
 
 cdef _type cpp_type_for(object obj) except *:
     cdef _type tp = xtype_for_prefix(obj)

--- a/dynd/ndt/type.pyx
+++ b/dynd/ndt/type.pyx
@@ -4,7 +4,7 @@ from cpython.object cimport Py_EQ, Py_NE, PyObject, PyTypeObject
 from libc.stdint cimport (intptr_t, int8_t, int16_t, int32_t, int64_t,
                           uint8_t, uint16_t, uint32_t, uint64_t)
 from libcpp.map cimport map
-from libcpp.string cimport string
+from libcpp.string cimport string as cpp_string
 from libcpp.vector cimport vector
 from libcpp.pair cimport pair
 from libcpp cimport bool as cpp_bool
@@ -61,7 +61,7 @@ cdef extern from "type_conversions.hpp" namespace 'pydynd':
 cdef extern from 'type_functions.hpp' namespace 'pydynd':
     object _type_get_shape(_type&) except +translate_exception
     object _type_get_id(_type&) except +translate_exception
-    string _type_str(_type &)
+    cpp_string _type_str(_type &)
 
     _type dynd_make_fixed_string_type(int, object) except +translate_exception
     _type dynd_make_string_type() except +translate_exception
@@ -97,11 +97,14 @@ init_type_functions()
 numpy_interop_init()
 _builtin_type = __builtins__.type
 _builtin_bool = __builtins__.bool
+_builtin_bytes = __builtins__.bytes
 
-__all__ = ['type_ids', 'type', 'bool', 'int8', 'int16', 'int32', 'int64', 'int128', \
-    'uint8', 'uint16', 'uint32', 'uint64', 'uint128', 'float16', 'float32', \
-    'float64', 'float128', 'complex_float32', 'complex_float64', 'void', \
-    'tuple', 'struct', 'callable', 'scalar', 'astype']
+__all__ = ['type_ids', 'type', 'bool', 'int8', 'int16', 'int32', 'int64', 'int128',
+    'uint8', 'uint16', 'uint32', 'uint64', 'uint128', 'float16', 'float32',
+    'float64', 'float128', 'complex64', 'complex_float32',
+    'complex128', 'complex_float64', 'void', 'intptr', 'uintptr', 'string',
+    'bytes', 'tuple', 'struct', 'callable',
+    'scalar', 'astype']
 
 type_ids = {}
 type_ids['UNINITIALIZED'] = uninitialized_id
@@ -383,7 +386,7 @@ cdef _type cpp_type_from_typeobject(object o) except *:
         return make_type[dynd_complex[double]]()
     elif o is str or o is unicode:
         return make_type[string_type]()
-    elif o is bytes:
+    elif o is _builtin_bytes:
         return make_type[bytes_type]()
     elif o is bytearray:
         return make_type[bytes_type]()
@@ -398,10 +401,10 @@ cdef _type as_cpp_type(object o) except *:
         return dynd_ndt_type_to_cpp(<type>o)
     elif _builtin_type(o) is str or PyUnicode_Check(<PyObject*>o):
         # Use Cython's automatic conversion to c++ strings.
-        return _type(<string>o)
+        return _type(<cpp_string>o)
     elif is_numpy_dtype(<PyObject*>o):
         return _type_from_numpy_dtype(<PyArray_Descr*>o)
-    elif issubclass(o, _ctypes_base_type):
+    elif _builtin_type(o) is _builtin_type and issubclass(o, _ctypes_base_type):
         raise ValueError("Conversion from ctypes type to DyND type not currently supported.")
     elif PyType_Check(<PyObject*>o):
         return cpp_type_from_typeobject(o)
@@ -594,24 +597,33 @@ def make_var_dim(element_tp):
     result.v = make_type[_var_dim_type](as_cpp_type(element_tp))
     return result
 
-bool = type(bool_id)
-int8 = type(int8_id)
-int16 = type(int16_id)
-int32 = type(int32_id)
-int64 = type(int64_id)
-int128 = type(int128_id)
-uint8 = type(uint8_id)
-uint16 = type(uint16_id)
-uint32 = type(uint32_id)
-uint64 = type(uint64_id)
-uint128 = type(uint128_id)
-float16 = type(float16_id)
-float32 = type(float32_id)
-float64 = type(float64_id)
-float128 = type(float128_id)
-complex_float32 = type(complex_float32_id)
-complex_float64 = type(complex_float64_id)
-void = type(void_id)
+bool = type('bool')
+int8 = type('int8')
+int16 = type('int16')
+int32 = type('int32')
+int64 = type('int64')
+int128 = type('int128')
+uint8 = type('uint8')
+uint16 = type('uint16')
+uint32 = type('uint32')
+uint64 = type('uint64')
+uint128 = type('uint128')
+float16 = type('float16')
+float32 = type('float32')
+float64 = type('float64')
+float128 = type('float128')
+# Until we have some sort of indexing scheme
+# for parameterized types exposed to Python,
+# we will have to use these aliases for complex types.
+complex64 = type('complex64')
+complex_float32 = complex64
+complex128 = type('complex128')
+complex_float64 = complex128
+void = type('void')
+intptr = type('intptr')
+uintptr = type('uintptr')
+string = type('string')
+bytes = type('bytes')
 
 def tuple(*args):
     cdef vector[_type] _args
@@ -630,14 +642,12 @@ def tuple(*args):
 
     return wrap(make_type[tuple_type]())
 
-from libcpp.string cimport string
-
 def struct(**kwds):
     # TODO: require an ordered dict here since struct types are ordered.
     # TODO: Use something other than dynd arrays to pass these arguments.
     #       See the comment in the tuple function for details.
     cdef vector[_type] _kwds
-    cdef vector[string] _names
+    cdef vector[cpp_string] _names
 
     if kwds:
         for kwd in kwds.values():

--- a/dynd/src/array_from_py.cpp
+++ b/dynd/src/array_from_py.cpp
@@ -235,7 +235,7 @@ static dynd::nd::array array_from_pylist(PyObject *obj)
   // TODO: Add ability to specify access flags (e.g. immutable)
   // Do a pass through all the data to deduce its type and shape
   vector<intptr_t> shape;
-  ndt::type tp(void_id);
+  ndt::type tp = ndt::make_type<void>();
   Py_ssize_t size = PyList_GET_SIZE(obj);
   shape.push_back(size);
   for (Py_ssize_t i = 0; i < size; ++i) {

--- a/dynd/src/type_conversions.cpp
+++ b/dynd/src/type_conversions.cpp
@@ -1,8 +1,4 @@
-#include <cstdint>
-
-#include "type_functions.hpp"
-
-#include "type_deduction.hpp"
+#include "type_conversions.hpp"
 
 #include "type_api.h"
 
@@ -67,23 +63,4 @@ dynd::ndt::type pydynd::dynd_ndt_cpp_type_for(PyObject *o)
     }
   }
   return cpp_type_for(o);
-}
-
-dynd::ndt::type pydynd::ndt_type_from_pylist(PyObject *obj)
-{
-  // TODO: Add ability to specify access flags (e.g. immutable)
-  // Do a pass through all the data to deduce its type and shape
-  std::vector<intptr_t> shape;
-  dynd::ndt::type tp = dynd::ndt::make_type<void>();
-  Py_ssize_t size = PyList_GET_SIZE(obj);
-  shape.push_back(size);
-  for (Py_ssize_t i = 0; i < size; ++i) {
-    deduce_pylist_shape_and_dtype(PyList_GET_ITEM(obj, i), shape, tp, 1);
-  }
-
-  if (tp.get_id() == dynd::void_id) {
-    tp = dynd::ndt::make_type<int32_t>();
-  }
-
-  return dynd::ndt::make_type(shape.size(), shape.data(), tp);
 }

--- a/dynd/src/type_conversions.cpp
+++ b/dynd/src/type_conversions.cpp
@@ -1,5 +1,9 @@
+#include <cstdint>
+
 #include "type_functions.hpp"
+
 #include "type_deduction.hpp"
+
 #include "type_api.h"
 
 dynd::ndt::type &pydynd::type_to_cpp_ref(PyObject *o)
@@ -70,7 +74,7 @@ dynd::ndt::type pydynd::ndt_type_from_pylist(PyObject *obj)
   // TODO: Add ability to specify access flags (e.g. immutable)
   // Do a pass through all the data to deduce its type and shape
   std::vector<intptr_t> shape;
-  dynd::ndt::type tp(dynd::void_id);
+  dynd::ndt::type tp = dynd::ndt::make_type<void>();
   Py_ssize_t size = PyList_GET_SIZE(obj);
   shape.push_back(size);
   for (Py_ssize_t i = 0; i < size; ++i) {
@@ -78,7 +82,7 @@ dynd::ndt::type pydynd::ndt_type_from_pylist(PyObject *obj)
   }
 
   if (tp.get_id() == dynd::void_id) {
-    tp = dynd::ndt::type(dynd::int32_id);
+    tp = dynd::ndt::make_type<int32_t>();
   }
 
   return dynd::ndt::make_type(shape.size(), shape.data(), tp);

--- a/dynd/src/type_deduction.cpp
+++ b/dynd/src/type_deduction.cpp
@@ -323,3 +323,22 @@ dynd::ndt::type pydynd::xtype_for_prefix(PyObject *obj)
 
   return dynd::ndt::type();
 }
+
+dynd::ndt::type pydynd::ndt_type_from_pylist(PyObject *obj)
+{
+  // TODO: Add ability to specify access flags (e.g. immutable)
+  // Do a pass through all the data to deduce its type and shape
+  std::vector<intptr_t> shape;
+  dynd::ndt::type tp = dynd::ndt::make_type<void>();
+  Py_ssize_t size = PyList_GET_SIZE(obj);
+  shape.push_back(size);
+  for (Py_ssize_t i = 0; i < size; ++i) {
+    deduce_pylist_shape_and_dtype(PyList_GET_ITEM(obj, i), shape, tp, 1);
+  }
+
+  if (tp.get_id() == dynd::void_id) {
+    tp = dynd::ndt::make_type<int32_t>();
+  }
+
+  return dynd::ndt::make_type(shape.size(), shape.data(), tp);
+}


### PR DESCRIPTION
Bugfixes to bring dynd-python into sync with https://github.com/libdynd/libdynd/pull/1254. Several bits of random cleanup that I took care of along the way are also included.
We should discuss what the best way is to map type ids back to types (or how to eliminate a few remaining cases where that needs to happen). Here I ended up having to use `dynd::ndt::infos()` in a few places, and that seems less than ideal.