### PR TITLE
Setup target arg

### DIFF
--- a/dynd/__init__.py
+++ b/dynd/__init__.py
@@ -6,24 +6,17 @@ except ImportError:
     import pkgutil
     __path__ = pkgutil.extend_path(__path__, __name__)
 
-try: # Only the import from dynd.ndt is expected to succeed.
+# The 'common' import is only supposed to work from the dynd.ndt sub-package.
+# If dynd.nd/dynd/__init__.py and dynd.ndt/dynd/__init__.py are the same file,
+# this ImportError must be ignored. The alternative is to ship two different
+# __init__.py files and remove the import from dynd.nd/dynd/__init__.py.
+try:
     from .common import *
 except ImportError:
     pass
 
 __all__ = [
-    '__libdynd_version__', '__version__', '__libdynd_git_sha1__', ' __git_sha1__',
+    '__libdynd_version__', '__version__', '__libdynd_git_sha1__', '__git_sha1__',
     'annotate', 'test', 'load'
 ]
-
-
-try: del common
-except: pass
-
-try: del pkgutil
-except: pass
-
-try: del pkg_resources
-except: pass
-
 

--- a/dynd/common/__init__.py
+++ b/dynd/common/__init__.py
@@ -1,3 +1,60 @@
+
+def _load_win_dll(dirname, dll):
+    # Manually load dlls before loading the extension modules.
+    # This is handled via rpaths on Unix based systems.
+    import ctypes
+    import sys
+    import os.path
+    def load_dynd_dll(rootpath):
+        try:
+            ctypes.cdll.LoadLibrary(os.path.join(rootpath, dll))
+            return True
+        except OSError:
+            return False
+    # If the dll has been placed in the dynd-python installation, use that
+    loaded = load_dynd_dll(dirname)
+    # Next, try the default DLL search path
+    loaded = loaded or load_dynd_dll('')
+    if not loaded:
+        # Try to load it from the Program Files directories where libdynd
+        # installs by default. This matches the search path for libdynd used
+        # in the CMake build for dynd-python.
+        is_64_bit = sys.maxsize > 2**32
+        processor_arch = os.environ.get('PROCESSOR_ARCHITECTURE')
+        err_str = ('Fallback search for %s failed because the "{}" '
+                   'environment variable was not set. Please make sure that '
+                   'either %s is on the DLL search path or that it is '
+                   'in the default install directory and the runtime '
+                   'environment has the necessary system-specified '
+                   'environment variables properly set. On 64 bit Windows '
+                   'with 64 bit Python the needed variables are '
+                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles". On 64 bit '
+                   'Windows with 32 bit Python the needed variables are '
+                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles(x86)". On 32 '
+                   'bit Windows the needed variables are '
+                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles".' % (dll, dll))
+        if processor_arch is None:
+            raise RuntimeError(err_str.format('PROCESSOR_ARCHITECTURE'))
+        is_32_on_64_bit = (is_64_bit and not processor_arch.endswith('64'))
+        if not is_32_on_64_bit:
+            prog_files = os.environ.get('ProgramFiles')
+            if prog_files is None:
+                raise RuntimeError(err_str.format('ProgramFiles'))
+        else:
+            prog_files = os.environ.get('ProgramFiles(x86)')
+            if prog_files is None:
+                raise RuntimeError(err_str.format('ProgramFiles(x86)'))
+        dynd_lib_dir = os.path.join(prog_files, 'libdynd', 'lib')
+        if os.path.isdir(dynd_lib_dir):
+            loaded = load_dynd_dll(dynd_lib_dir)
+            if not loaded:
+                raise ctypes.WinError(126, 'Could not load %s' % dll)
+
+import os, os.path
+if os.name == 'nt':
+    _load_win_dll(os.path.dirname(os.path.dirname(__file__)), 'libdyndt.dll')
+
+
 from ..config import _dynd_version_string as __libdynd_version__, \
                      _dynd_python_version_string as __version__, \
                      _dynd_git_sha1 as __libdynd_git_sha1__, \

--- a/dynd/nd/__init__.py
+++ b/dynd/nd/__init__.py
@@ -1,58 +1,9 @@
-from .. import ndt # ensure that the module is loaded first
+from ..common import _load_win_dll # this also ensures that libdyndt is loaded first
+import os, os.path
 import sys
-import os
 
 if os.name == 'nt':
-    # Manually load dlls before loading the extension modules.
-    # This is handled via rpaths on Unix based systems.
-    import ctypes
-    import os.path
-    def load_dynd_dll(rootpath):
-        try:
-            ctypes.cdll.LoadLibrary(os.path.join(rootpath, 'libdynd.dll'))
-            return True
-        except OSError:
-            return False
-    # If libdynd.dll has been placed in the dynd-python installation, use that
-    nddir = os.path.dirname(os.path.dirname(__file__))
-    loaded = load_dynd_dll(nddir)
-    # Next, try the default DLL search path
-    loaded = loaded or load_dynd_dll('')
-    if not loaded:
-        # Try to load it from the Program Files directories where libdynd
-        # installs by default. This matches the search path for libdynd used
-        # in the CMake build for dynd-python.
-        is_64_bit = sys.maxsize > 2**32
-        processor_arch = os.environ.get('PROCESSOR_ARCHITECTURE')
-        err_str = ('Fallback search for libdynd.dll failed because the "{}" '
-                   'environment variable was not set. Please make sure that '
-                   'either libdynd is on the DLL search path or that it is '
-                   'in the default install directory and the runtime '
-                   'environment has the necessary system-specified '
-                   'environment variables properly set. On 64 bit Windows '
-                   'with 64 bit Python the needed variables are '
-                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles". On 64 bit '
-                   'Windows with 32 bit Python the needed variables are '
-                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles(x86)". On 32 '
-                   'bit Windows the needed variables are '
-                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles".')
-        if processor_arch is None:
-            raise RuntimeError(err_str.format('PROCESSOR_ARCHITECTURE'))
-        is_32_on_64_bit = (is_64_bit and not processor_arch.endswith('64'))
-        if not is_32_on_64_bit:
-            prog_files = os.environ.get('ProgramFiles')
-            if prog_files is None:
-                raise RuntimeError(err_str.format('ProgramFiles'))
-        else:
-            prog_files = os.environ.get('ProgramFiles(x86)')
-            if prog_files is None:
-                raise RuntimeError(err_str.format('ProgramFiles(x86)'))
-        dynd_lib_dir = os.path.join(prog_files, 'libdynd', 'lib')
-        if os.path.isdir(dynd_lib_dir):
-            loaded = load_dynd_dll(dynd_lib_dir)
-            if not loaded:
-                raise ctypes.WinError(126, 'Could not load libdynd.dll')
-
+    _load_win_dll(os.path.dirname(os.path.dirname(__file__)), 'libdynd.dll')
 
 from dynd.config import *
 
@@ -74,7 +25,3 @@ from . import functional
 #        return _parse(tp, obj)
 
 publish_callables(sys.modules[__name__])
-
-del os
-del sys
-del ndt

--- a/dynd/ndt/__init__.py
+++ b/dynd/ndt/__init__.py
@@ -1,56 +1,4 @@
-import sys
-import os
-
-if os.name == 'nt':
-    # Manually load dlls before loading the extension modules.
-    # This is handled via rpaths on Unix based systems.
-    import ctypes
-    import os.path
-    def load_dynd_dll(rootpath):
-        try:
-            ctypes.cdll.LoadLibrary(os.path.join(rootpath, 'libdyndt.dll'))
-            return True
-        except OSError:
-            return False
-    # If libdyndt.dll has been placed in the dynd-python installation, use that
-    ndtdir = os.path.dirname(os.path.dirname(__file__))
-    loaded = load_dynd_dll(ndtdir)
-    # Next, try the default DLL search path
-    loaded = loaded or load_dynd_dll('')
-    if not loaded:
-        # Try to load it from the Program Files directories where libdynd
-        # installs by default. This matches the search path for libdynd used
-        # in the CMake build for dynd-python.
-        is_64_bit = sys.maxsize > 2**32
-        processor_arch = os.environ.get('PROCESSOR_ARCHITECTURE')
-        err_str = ('Fallback search for libdyndt.dll failed because the "{}" '
-                   'environment variable was not set. Please make sure that '
-                   'either libdyndt is on the DLL search path or that it is '
-                   'in the default install directory and the runtime '
-                   'environment has the necessary system-specified '
-                   'environment variables properly set. On 64 bit Windows '
-                   'with 64 bit Python the needed variables are '
-                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles". On 64 bit '
-                   'Windows with 32 bit Python the needed variables are '
-                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles(x86)". On 32 '
-                   'bit Windows the needed variables are '
-                   '"PROCESSOR_ARCHITECTURE" and "ProgramFiles".')
-        if processor_arch is None:
-            raise RuntimeError(err_str.format('PROCESSOR_ARCHITECTURE'))
-        is_32_on_64_bit = (is_64_bit and not processor_arch.endswith('64'))
-        if not is_32_on_64_bit:
-            prog_files = os.environ.get('ProgramFiles')
-            if prog_files is None:
-                raise RuntimeError(err_str.format('ProgramFiles'))
-        else:
-            prog_files = os.environ.get('ProgramFiles(x86)')
-            if prog_files is None:
-                raise RuntimeError(err_str.format('ProgramFiles(x86)'))
-        dynd_lib_dir = os.path.join(prog_files, 'libdynd', 'lib')
-        if os.path.isdir(dynd_lib_dir):
-            loaded = load_dynd_dll(dynd_lib_dir)
-            if not loaded:
-                raise ctypes.WinError(126, 'Could not load libdyndt.dll')
+from .. import common # ensure that libdyndt is loaded
 
 from .type import make_fixed_bytes, make_fixed_string, make_struct, \
     make_fixed_dim, make_string, make_var_dim, make_fixed_dim_kind, \
@@ -63,6 +11,3 @@ from .dim_helpers import *
 from . import dynd_ctypes as ctypes
 
 from . import json
-
-del os
-del sys

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,15 @@ import shlex, glob
 from subprocess import check_output
 
 import re
+import argparse
+
+# Pre-parse and remove the '--target' argument from sys.argv since we
+# need it here already.
+parser = argparse.ArgumentParser()
+parser.add_argument('--target', default='all')
+values, rest = parser.parse_known_args()
+DIST_TARGET = values.target
+sys.argv = sys.argv[:1] + rest
 
 #
 # DyND is a namespace package that contains the type module dynd.ndt and
@@ -32,11 +41,10 @@ import re
 # option 2) followed by option 3).  All options require a clean build
 # directory. At the minimum build/, dist/ and dynd.egg* must be removed.
 #
-DIST_TARGET = 'all'
 class Target():
   def __init__(self, target):
     if target not in ['ndt', 'nd', 'all']:
-      raise ValueError("unknown distribution target: %s" % target)
+      raise ValueError("unknown distribution target: '%s'" % target)
     self.target = target
 
   def get_name(self):


### PR DESCRIPTION
This adds a --target argument to setup.py.  It would be great to have this in because it avoids some ugly hacks in the conda build that I'm working on.

The --target argument is pre-parsed and removed from sys.argv. The rest of the args is passed on to build_ext/install/build as usual.

The diff also contains all changes from https://github.com/libdynd/dynd-python/pull/710 , which should go in first.