### PR TITLE
Use conda build exclusively to test installation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,9 +79,6 @@ script:
   - conda build conda/ndt.recipe --channel dynd/channel/dev
   - rm -rf build dynd.ndt.egg-info
   - conda build conda/nd.recipe --channel dynd/channel/dev
-  - conda install --yes numpy libdynd --channel dynd/channel/dev
-  - conda install $(conda build --output conda/ndt.recipe | grep bz2)
-  - conda install $(conda build --output conda/nd.recipe | grep bz2)
 
 after_success:
   - if [ $TRAVIS_BRANCH == "master" ] && [ $TRAVIS_PULL_REQUEST == "false" ]; then anaconda --token $ANACONDA_TOKEN upload $(conda build --output conda/ndt.recipe) --user dynd --channel dev; fi

--- a/conda/nd.recipe/meta.yaml
+++ b/conda/nd.recipe/meta.yaml
@@ -29,10 +29,9 @@ requirements:
     - libdynd
     - libgcc >=5.2    # [linux]
 
-# Test separately to avoid unsatisfiable package dependencies bug on Win32.
 test:
   requires:
-    - numba
+    - numba >=0.25.0
   commands:
     - python -m dynd.nd.test
 

--- a/conda/ndt.recipe/meta.yaml
+++ b/conda/ndt.recipe/meta.yaml
@@ -32,7 +32,6 @@ requirements:
     - libdynd {{ version }}
     - libgcc >=5.2    # [linux]
 
-# Test separately to avoid unsatisfiable package dependencies bug on Win32.
 test:
   requires:
     - numba >=0.25.0


### PR DESCRIPTION
Installing a package from a file url is broken in conda 4.1.8, but it's
not something we actually need for our tests anyway.

Should work around https://github.com/conda/conda/issues/2845#issuecomment-233145892.