### PR TITLE
Relocate dynamic propagation of registry to Python namespaces

### DIFF
--- a/dynd/__init__.py
+++ b/dynd/__init__.py
@@ -19,7 +19,3 @@ __all__ = [
     '__libdynd_version__', '__version__', '__libdynd_git_sha1__', '__git_sha1__',
     'annotate', 'test', 'load'
 ]
-
-from .nd.registry import propagate_all
-
-propagate_all()

--- a/dynd/nd/__init__.py
+++ b/dynd/nd/__init__.py
@@ -12,7 +12,11 @@ from .array import array, asarray, type_of, dshape_of, as_py, view, \
     parse_json, squeeze, dtype_of, old_linspace, fields, ndim_of
 from .callable import callable
 
+from . import functional
+
+from .registry import propagate_all
+
+propagate_all()
+
 inf = float('inf')
 nan = float('nan')
-
-from . import functional


### PR DESCRIPTION
Move dynamic propagation of registry into Python namespaces out of
the main dynd namespace.
This is primarily a stopgap to get the CI tests working again
before moving this registration code into the type related portion of
dynd-python.